### PR TITLE
Include instructions for cloning VVV

### DIFF
--- a/index.md
+++ b/index.md
@@ -24,7 +24,9 @@ In addition to VirtualBox, provider support is also included for Parallels, Hype
 1. (Optional) Install the [vagrant-triggers](https://github.com/emyl/vagrant-triggers) plugin with `vagrant plugin install vagrant-triggers`
     * Note: This step is not a requirement. When installed, it allows for various scripts to fire when issuing commands such as `vagrant halt` and `vagrant destroy`.
 1. (Optional) Install the [vagrant-vbguest](https://github.com/dotless-de/vagrant-vbguest) plugin with `vagrant plugin install vagrant-vbguest`.
-1. Clone or download and extract the Varying Vagrant Vagrants project into a local directory
+1. Clone or download and extract the Varying Vagrant Vagrants project from GitHub into a local directory, using either:
+    * SSH: `git clone git@github.com:Varying-Vagrant-Vagrants/VVV.git .`
+    * HTTPS: `git clone https://github.com/Varying-Vagrant-Vagrants/VVV.git .`
 1. In a command prompt, change into the new directory with `cd vagrant-local`
 1. Start the Vagrant environment with `vagrant up`
     * Be patient as the magic happens. This could take a while on the first run as your local machine downloads the required files.

--- a/index.md
+++ b/index.md
@@ -27,6 +27,7 @@ In addition to VirtualBox, provider support is also included for Parallels, Hype
 1. Clone or download and extract the Varying Vagrant Vagrants project from GitHub into a local directory, using either:
     * SSH: `git clone git@github.com:Varying-Vagrant-Vagrants/VVV.git .`
     * HTTPS: `git clone https://github.com/Varying-Vagrant-Vagrants/VVV.git .`
+    * Download: https://github.com/Varying-Vagrant-Vagrants/VVV/archive/develop.zip
 1. In a command prompt, change into the new directory with `cd vagrant-local`
 1. Start the Vagrant environment with `vagrant up`
     * Be patient as the magic happens. This could take a while on the first run as your local machine downloads the required files.

--- a/index.md
+++ b/index.md
@@ -27,7 +27,7 @@ In addition to VirtualBox, provider support is also included for Parallels, Hype
 1. Clone or download and extract the Varying Vagrant Vagrants project from GitHub into a local directory, using either:
     * SSH: `git clone git@github.com:Varying-Vagrant-Vagrants/VVV.git .`
     * HTTPS: `git clone https://github.com/Varying-Vagrant-Vagrants/VVV.git .`
-    * Download: https://github.com/Varying-Vagrant-Vagrants/VVV/archive/develop.zip
+    * Download: [https://github.com/Varying-Vagrant-Vagrants/VVV/archive/develop.zip](https://github.com/Varying-Vagrant-Vagrants/VVV/archive/develop.zip)
 1. In a command prompt, change into the new directory with `cd vagrant-local`
 1. Start the Vagrant environment with `vagrant up`
     * Be patient as the magic happens. This could take a while on the first run as your local machine downloads the required files.


### PR DESCRIPTION
These instructions were copied from the README.md from VVV. Without that context, this page is missing the connection to the GitHub repository to actually clone VVV, leaving a big gap in the instructions.

This change adds code for cloning either the SSH and the HTTPS methods, making for easy copy & paste, similar to the vagrant plugins.
