### PR TITLE
[PR] Update installation instructions to clone VVV into directory utilized later in `index.md`

### DIFF
--- a/index.md
+++ b/index.md
@@ -25,8 +25,8 @@ In addition to VirtualBox, provider support is also included for Parallels, Hype
     * Note: This step is not a requirement. When installed, it allows for various scripts to fire when issuing commands such as `vagrant halt` and `vagrant destroy`.
 1. (Optional) Install the [vagrant-vbguest](https://github.com/dotless-de/vagrant-vbguest) plugin with `vagrant plugin install vagrant-vbguest`.
 1. Clone or download and extract the Varying Vagrant Vagrants project from GitHub into a local directory, using either:
-    * SSH: `git clone git@github.com:Varying-Vagrant-Vagrants/VVV.git .`
-    * HTTPS: `git clone https://github.com/Varying-Vagrant-Vagrants/VVV.git .`
+    * SSH: `git clone git@github.com:Varying-Vagrant-Vagrants/VVV.git vagrant-local`
+    * HTTPS: `git clone https://github.com/Varying-Vagrant-Vagrants/VVV.git vagrant-local`
     * Download: [https://github.com/Varying-Vagrant-Vagrants/VVV/archive/develop.zip](https://github.com/Varying-Vagrant-Vagrants/VVV/archive/develop.zip)
 1. In a command prompt, change into the new directory with `cd vagrant-local`
 1. Start the Vagrant environment with `vagrant up`


### PR DESCRIPTION
The existing instructions suggest cloning the VVV repository directly into the current directory (`.`), and direct users to switch to the directory containing vvv (`vagrant-local`) thereafter. In order to make directions directly followable, we correct this inconsistency.

The switch directory step has been retained as users who use the downloadable zip version will be presented with a subdirectory upon extracting the archive. This archive _does not_ match the folder name utilized in the directions; I've chosen to leave this inconsistency as the name that we'd need to use (`VVV-develop`) seems out of place to recommend in the `git clone` instructions.