### PR TITLE
Fixes Jekyll deprecation warning

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -11,7 +11,7 @@ email: jeremy.felt@gmail.com
 baseurl: "" # the subpath of your site, e.g. /blog
 url: "https://varyingvagrantvagrants.org" # the base hostname & protocol for your site
 markdown: kramdown
-gems: [jekyll-paginate]
+plugins: [jekyll-paginate]
 permalink: /blog/:year/:month/:day/:title.html
 paginate: 10
 paginate_path: /blog/page:num


### PR DESCRIPTION
```
Deprecation: The 'gems' configuration option has been renamed to 'plugins'. Please update your config file accordingly.
```

Fixed and tested