### PR TITLE
Transfer documentation from VVV develop branch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 _site
-docs
 .sass-cache
 .jekyll-metadata
 Gemfile.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,10 @@ rvm:
   - 2.4.0
 
 before_script:
-  - wget "https://github.com/Varying-Vagrant-Vagrants/VVV/archive/master.zip" -P /tmp/vvv
-  - unzip /tmp/vvv/master.zip -d /tmp/vvv/
-  - mv /tmp/vvv/VVV-master/docs ./
-  - cp /tmp/vvv/VVV-master/.github/CONTRIBUTING.md ./docs/en-US/contributing.md
-  - cp /tmp/vvv/VVV-master/CHANGELOG.md ./docs/en-US/changelog.md
+  - wget "https://github.com/Varying-Vagrant-Vagrants/VVV/archive/develop.zip" -P /tmp/vvv
+  - unzip /tmp/vvv/develop.zip -d /tmp/vvv/
+  - cp /tmp/vvv/VVV-develop/.github/CONTRIBUTING.md ./docs/en-US/contributing.md
+  - cp /tmp/vvv/VVV-develop/CHANGELOG.md ./docs/en-US/changelog.md
 
 script:
   - bundle exec jekyll --version

--- a/docs/en-US/adding-a-new-site/changing-php-version.md
+++ b/docs/en-US/adding-a-new-site/changing-php-version.md
@@ -1,0 +1,73 @@
+---
+layout: page
+title: Changing PHP Version
+permalink: /docs/en-US/adding-a-new-site/changing-php-version/
+---
+
+* [Add New Sites](index.md)
+   * [Changing a sites PHP Version](changing-php-version.md)
+   * [Custom Domains and Hosts](custom-domains-hosts.md)
+   * [Custom Paths and Folders](custom-paths-and-folders.md)
+   * [Nginx Configs](nginx-configs.md)
+   * [Setup Scripts](setup-script.md)
+
+You can set the PHP version in `vvv-custom.yml` when defining a site. To do this, use the `nginx_upstream` option to specify the PHP version. VVV also needs to be told to install that version of PHP using the `utilities` section.
+
+Here’s an example that uses PHP v7.1:
+
+```YAML
+sites:
+  example:
+    nginx_upstream: php71
+
+utilities:
+  core:
+    - php71
+```
+
+This will not work if `set $upstream {upstream};` is removed from the nginx config.
+
+In this example, we have changed the `wordpress-default` site to use PHP 7.1, and the `wordpress-develop` site to use PHP 5.6:
+
+```YAML
+sites:
+  wordpress-default:
+    repo: https://github.com/Varying-Vagrant-Vagrants/vvv-wordpress-default.git
+    nginx_upstream: php71
+    hosts:
+      - local.wordpress.dev
+
+  wordpress-develop:
+    repo: https://github.com/Varying-Vagrant-Vagrants/vvv-wordpress-develop.git
+    nginx_upstream: php56
+    hosts:
+      - src.wordpress-develop.dev
+      - build.wordpress-develop.dev
+
+utilities:
+  core:
+    - memcached-admin
+    - opcache-status
+    - phpmyadmin
+    - webgrind
+    - php56
+    - php71
+```
+
+## Forcing a Version of PHP
+
+It may be desirable to force a site to use a particular version of PHP, even if `vvv-custom.yml` disagrees.
+
+This is done by overriding the nginx upstream value inside `vvv-nginx.conf`. To do this change this:
+
+```nginx
+ set $upstream {upstream};
+```
+
+To this:
+
+```nginx
+ set $upstream php71;
+```
+
+That site is now using PHP 7.1, remember to reprovision using `vagrant reload --provision`

--- a/docs/en-US/adding-a-new-site/custom-domains-hosts.md
+++ b/docs/en-US/adding-a-new-site/custom-domains-hosts.md
@@ -1,0 +1,47 @@
+---
+layout: page
+title: Custom Domains and Hosts
+permalink: /docs/en-US/adding-a-new-site/custom-domains-hosts/
+---
+
+* [Add New Sites](index.md)
+   * [Changing a sites PHP Version](changing-php-version.md)
+   * [Custom Domains and Hosts](custom-domains-hosts.md)
+   * [Custom Paths and Folders](custom-paths-and-folders.md)
+   * [Nginx Configs](nginx-configs.md)
+   * [Setup Scripts](setup-script.md)
+
+There are 3 ways to define hosts
+
+ - The main `vvv-custom.yml` config file
+ - A `vvv-hosts` file
+ - The `vvv-init.sh` file
+
+The recommended way is to use the `vvv-custom.yml` file. `vvv-hosts` is supported for backwards compatibility, and `vvv-init.sh` can be used for edge circumstances
+
+When changing hosts, the Nginx config will need updating so that Nginx knows to listen for requests on those domains. If this isn't done, the VVV dashboard will appear instead of the desired site.
+
+**Remember**, you need to reprovision for a change to take effect, run `vagrant reload` after making changes.
+
+## vvv-custom.yml
+
+When adding a site in `vvv-custom.yml`, add a hosts section listing the domains of that site. For example:
+
+```YAML
+example:
+  hosts:
+    - example.com
+```
+
+This will map example.com to the example site, and update the HOST file on your machine.
+
+## vvv-hosts
+
+VVV 1 added hosts using a file named `vvv-hosts`, and VVV 2 continues support for this for backwards compatibility reasons. Place this as a text file with no file extension in a `provision` subfolder, or in the root of the site.
+
+Here's an example that adds 2 domains:
+
+```
+example.com
+example.net
+```

--- a/docs/en-US/adding-a-new-site/custom-paths-and-folders.md
+++ b/docs/en-US/adding-a-new-site/custom-paths-and-folders.md
@@ -1,0 +1,42 @@
+---
+layout: page
+title: Custom Paths and Folders
+permalink: /docs/en-US/adding-a-new-site/custom-paths-and-folders/
+---
+
+* [Add New Sites](index.md)
+   * [Changing a sites PHP Version](changing-php-version.md)
+   * [Custom Domains and Hosts](custom-domains-hosts.md)
+   * [Custom Paths and Folders](custom-paths-and-folders.md)
+   * [Nginx Configs](nginx-configs.md)
+   * [Setup Scripts](setup-script.md)
+
+A site in a non-standard folder can still be used via the `vm_dir` and `local_dir` keys. `local_dir` tells VVV where the site is located on the host machine, and `vm_dir` tells VVV where the site is located inside the Virtual machine.
+
+For example, if we put our test sites in a subfolder, we can specify each site like this in the `sites` section:
+
+```YAML
+test-site-1:
+  vm_dir: /srv/www/test-sites/test-site-1
+  local_dir: www/test-sites/test-site-1
+  hosts:
+    - testsite1.com
+
+test-site-2:
+  vm_dir: /srv/www/test-sites/test-site-2
+  local_dir: www/test-sites/test-site-2
+  hosts:
+    - testsite2.com
+```
+
+In the above example, the `vm_dir` and `local_dir` point to the same folder (`vm_dir` needs to be an absolute path), however, this doesn’t have to be the case.
+
+In this example, VVV is told to use a site stored outside of the main VVV folder, and mapped to an absolute path in the virtual machine:
+
+```YAML
+example-site:
+  vm_dir: /srv/www/example-site
+  local_dir: /Users/janesmith/Documents/example-site
+  hosts:
+    - examplesite.com
+```

--- a/docs/en-US/adding-a-new-site/index.md
+++ b/docs/en-US/adding-a-new-site/index.md
@@ -1,0 +1,129 @@
+---
+layout: page
+title: Adding a New Site
+permalink: /docs/en-US/adding-a-new-site/
+---
+
+* [Add New Sites](index.md)
+   * [Changing a sites PHP Version](changing-php-version.md)
+   * [Custom Domains and Hosts](custom-domains-hosts.md)
+   * [Custom Paths and Folders](custom-paths-and-folders.md)
+   * [Nginx Configs](nginx-configs.md)
+   * [Setup Scripts](setup-script.md)
+
+Adding a new site is as simple as adding it under the sites section of `vvv-custom.yml`. If `vvv-custom.yml` does not exist, you can create it by copying `vvv-config.yml` to `vvv-custom.yml`.
+
+To do this there are five steps:
+
+ - `vvv-custom.yml` and the root folder ( the VVV folder )
+ - Files
+ - Provisioner files
+ - Restart/reprovision VVV
+ - Database
+
+I'm going to walk through setting up a blog named vvvtest.com locally using VVV, but this could be a site currently hosted in MAMP.
+
+If you're migrating a site from VVV 1, read this page, then visit the [migration page](../migrating-vvv1.md) for further details.
+
+You may also find that the default sites created by VVV are enough for what you need. [Read about the default sites here](../references/default-sites.md)
+
+**Remember: Always reprovision after making changes to `vvv-custom.yml`**
+
+## `vvv-custom.yml` and the Root Folder
+
+First we need to tell VVV about the site. I'm going to give the site the name `vvvtest`, and update the sites list in `vvv-custom.yml`:
+
+```YAML
+vvvtest:
+```
+
+We also want to specify the host as `vvvtest.com`:
+
+```YAML
+vvvtest:
+  hosts:
+    - vvvtest.com
+```
+
+Read here for [more information about Domains and hosts](custom-domains-hosts.md)
+
+## Files
+
+Now that VVV knows about our site with the name `vvvtest`, it's going to look inside the `www/vvvtest` folder for our site. We need to create and fill this folder. If I had named the site `testables`, the folder would be `www/testables`.
+
+After creating the folder, create a `provision` subfolder, e.g. `www/testables/provision`. See more below about what goes in this folder.
+
+If you'd like to change the folders VVV uses, [read here for more information](custom-paths-and-folders.md)
+
+### Copying In Site Files
+
+If you have an existing site you want to work with, you will be able to manually copy the site files into the `public_html` or equivalent subdirectory created when the site is provisioned.
+
+As an alternative, rather than manually copying files into the folder, copy them into a git repository, and use the `repo` key to tell VVV where to find it.
+
+With this, you can automate a large chunk of the work for new users when working in a team, and encourage healthy version control workflows!
+
+For example:
+
+```YAML
+vvvtest:
+  repo: https://github.com/Varying-Vagrant-Vagrants/custom-site-template.git
+  hosts:
+    - vvvtest.com
+```
+
+We **strongly** recommend this.
+
+## Provisioner Files
+
+The following files should be created within the `provision` folder created above:
+
+ - vvv-hosts
+ - vvv-init.sh
+ - vvv-nginx.conf
+
+`vvv-hosts` can be one line with the hostname of the new site set above, e.g. `vvvtest.com`.
+
+`vvv-init.sh` determines how VVV will download, install, and setup WordPress. [Read about `vvv-init.sh` and find an example to copy/paste here](setup-script.md).
+
+### Nginx config
+
+VVV uses Nginx as a web server, but Nginx needs to know how to serve a WP site. Luckily VVV provides those rules, requiring only a small config file that works for 99% of WP sites.
+
+For our example below, we only need to change the domain/host and copy paste the result into `provision/vvv-nginx.conf`:
+
+```nginx
+server {
+  listen 80;
+  listen 443 ssl;
+  server_name vvvtest.com;
+  root {vvv_path_to_site};
+
+  error_log {vvv_path_to_site}/log/error.log;
+  access_log {vvv_path_to_site}/log/access.log;
+
+  set $upstream {upstream};
+
+  include /etc/nginx/nginx-wp-common.conf;
+}
+```
+
+For more information about Nginx and VVV, read the [Nginx Configs page](nginx-configs.md) of adding a new site.
+
+## Reprovision
+
+Any time we make changes to `vvv-custom.yml` or the provisioner files of a site, we need to restart VVV. This allows VVV to catch up with the latest changes and activates your new site.
+
+To do this, run `vagrant reload --provision`.
+
+## Database
+
+Now our site is active and running in VVV, but there's no content. We need to transfer the database contents into the database running inside VVV.
+
+There are several ways to do this:
+
+ - Do the 5 minute install of WordPress and use the importer plugin
+ - Use the PHPMyAdmin install that comes with VVV, by visiting [http://vvv.dev](http://vvv.dev)
+ - Connect directly to the MySQL server using the default credentials
+ - Restore a backup via a plugin
+ - Automatically import an sql file in vvv-init.sh if the database is empty using the `mysql` command

--- a/docs/en-US/adding-a-new-site/migrating-vvv1.md
+++ b/docs/en-US/adding-a-new-site/migrating-vvv1.md
@@ -1,0 +1,61 @@
+---
+layout: page
+title: Migrating from VVV 1.4.x
+permalink: /docs/en-US/adding-a-new-site/migrating-from-vvv-1-4-x
+---
+
+# Migrating from VVV 1
+
+VVV 1 sites still work, but they require an additional step.
+
+## Telling VVV 2 About Your Site
+
+VVV 2 uses a config file to discover sites. Adding your site to this file will allow VVV 2 to provision and host it.
+
+If, for example, you have a site at `www/my-test-site`, you can migrate it to VVV2 by adding this to the `sites` section of `vvv-custom.yml`:
+
+```YAML
+my-test-site:
+```
+
+Turn your VVV instance off and on to reload the config, and VVV will now look inside `www/my-test-site` for provisioning files the same way VVV 1 does.
+
+### Git Repositories
+
+It's possible to specify a git repository rather than a folder, and VVV2 will clone it and provision the contents automatically, for example:
+
+```YAML
+my-test-site: https://github.com/etc.....
+```
+
+This will clone the git repository into `www/my-test-site` and provision the contents.
+
+This can also be done via the `repo` key, allowing extra options, such as hosts to be defined:
+
+```YAML
+my-test-site:
+  repo: https://github.com/etc.....
+  hosts:
+    - mytestsite.com
+```
+
+### VVV 1 Sites in Non-Standard Folders
+
+Some VVV 1 sites are in nested or non-standard folder structures. These are still supported. See the [custom paths and folders](custom-paths-and-folders.md) documentation for how to configure these sites.
+
+
+## Why is This Needed?
+
+VVV sites work the same way in VVV 1 and VVV 2, but with one major difference. VVV 2 uses a config file, and VVV 1 scans for sites automatically.
+
+### How VVV 1 Detects Sites
+
+When the v1 provisioner runs, it searches the VVV folder for `vvv-init.sh` and `vvv-nginx.conf` files. As a result VVV picked up sites regardless of location, even catching nested sites.
+
+But this caused performance problems. Folder scans could be very slow with some file systems, and there was no way to control which sites were provisioned. If you wanted to provision a site quickly, larger sites had to be moved out of the `www` folder.
+
+### How VVV 2 Detects Sites
+
+VVV 2 did away with site auto-detection. Instead VVV uses a config file named `vvv-custom.yml` that lists all the sites. This way a user can set the folder used via the `vm_dir` option, or skip provisioning via the `skip_provisioning` option.
+
+This also makes provisioning significantly faster, and allows for additional options.

--- a/docs/en-US/adding-a-new-site/nginx-configs.md
+++ b/docs/en-US/adding-a-new-site/nginx-configs.md
@@ -1,0 +1,84 @@
+---
+layout: page
+title: Nginx Configuration
+permalink: /docs/en-US/adding-a-new-site/nginx-configuration/
+---
+
+* [Add New Sites](index.md)
+   * [Changing a sites PHP Version](changing-php-version.md)
+   * [Custom Domains and Hosts](custom-domains-hosts.md)
+   * [Custom Paths and Folders](custom-paths-and-folders.md)
+   * [Nginx Configs](nginx-configs.md)
+   * [Setup Scripts](setup-script.md)
+
+Some sites use Apache or IIS to serve pages, but VVV uses the popular Nginx. VVV provides an include for setting up WordPress easily, and a file for setting your own Nginx configuration on a per site basis named `vvv-nginx.conf`
+
+## A Standard WordPress Nginx Configuration
+
+For most WordPress sites, this NGINX configuration will suffice:
+
+```Nginx
+server {
+  listen 80;
+  listen 443 ssl;
+  server_name {vvv_site_name}.local;
+  root {vvv_path_to_site}/public_html;
+
+  error_log {vvv_path_to_site}/log/error.log;
+  access_log {vvv_path_to_site}/log/access.log;
+
+  set $upstream {upstream};
+
+  include /etc/nginx/nginx-wp-common.conf;
+}
+```
+
+This will give you:
+
+ - a webroot folder `public_html`
+ - that serves sitename.local, where sitename is the name of your site in `vvv-custom.yml`
+ - Error and access logs in `log/error.log` and `log/access.log`
+
+You will need to create the `public_html` and `log` folders if they don't exist
+
+## nginx-wp-common.conf
+
+This is an Nginx config file provided by VVV. Including it pulls in a number of useful rules, such as PHP Fast CGI and rules for using Nginx with permalinks.
+
+While not required, it's strongly recommended that this config file is included.
+
+## Nginx Variable Replacements
+
+Before VVV copies the configs to there final location, it runs a search replace routine. This allows variables containing information about the site to be used inside the Nginx config.
+
+The config at the top of this page contains several examples. E.g. `{vvv_site_name}` is used to set the domain used, and `{vvv_path_to_site}` is used to set the root and log locations.
+
+## Nginx Upstream
+
+You may have noticed this line in the example above:
+
+```Nginx
+set $upstream {upstream};
+```
+
+The `{upstream}` variable is set from `vvv-custom.yml`, and is used to determine the version of PHP to use. Removing this will disable that functionality.
+
+It may be desirable to force a site to use a particular version of PHP, for details see the [changing PHP versions](changing-php-version.md) documentation.
+
+## PHP Error Logs
+
+```Nginx
+error_log {vvv_path_to_site}/log/error.log;
+access_log {vvv_path_to_site}/log/access.log;
+```
+
+These two lines tell Nginx where to log errors and requests to the site. In this example, the logs for the `example` site are located at `www/example/log/error.log`
+
+Because the logs are being saved in a subfolder, it will be necessary to create the `log` folder and initial log files during provision. To do this, add these lines to `vvv-init.sh`:
+
+```shell
+# Nginx Logs
+mkdir -p ${VVV_PATH_TO_SITE}/log
+touch ${VVV_PATH_TO_SITE}/log/error.log
+touch ${VVV_PATH_TO_SITE}/log/access.log
+```

--- a/docs/en-US/adding-a-new-site/setup-script.md
+++ b/docs/en-US/adding-a-new-site/setup-script.md
@@ -1,0 +1,58 @@
+---
+layout: page
+title: Setup Script
+permalink: /docs/en-US/adding-a-new-site/setup-script/
+---
+
+* [Add New Sites](index.md)
+   * [Changing a sites PHP Version](changing-php-version.md)
+   * [Custom Domains and Hosts](custom-domains-hosts.md)
+   * [Custom Paths and Folders](custom-paths-and-folders.md)
+   * [Nginx Configs](nginx-configs.md)
+   * [Setup Scripts](setup-script.md)
+
+`vvv-init.sh` is ran when VVV sets up the site, and gives you an opportunity to execute shell commands, including WP CLI commands. This file is optional, but when combined with a git repository this becomes very powerful.
+
+Your script might:
+ - Download and install the latest WordPress
+ - Update and install plugins
+ - Checkout extra git repos
+ - Run `composer install` and other dependency managers and task runners
+ - Create an empty database if it doesn't exist and fill it with starter content
+
+#### An Example
+
+Here is an example script that will work for a basic WordPress multisite install:
+
+```shell
+#!/usr/bin/env bash
+
+# Add the site name to the hosts file
+echo "127.0.0.1 ${VVV_SITE_NAME}.local # vvv-auto" >> "/etc/hosts"
+
+# Make a database, if we don't already have one
+echo -e "\nCreating database '${VVV_SITE_NAME}' (if it's not already there)"
+mysql -u root --password=root -e "CREATE DATABASE IF NOT EXISTS ${VVV_SITE_NAME}"
+mysql -u root --password=root -e "GRANT ALL PRIVILEGES ON ${VVV_SITE_NAME}.* TO wp@localhost IDENTIFIED BY 'wp';"
+echo -e "\n DB operations done.\n\n"
+
+# Nginx Logs
+mkdir -p ${VVV_PATH_TO_SITE}/log
+touch ${VVV_PATH_TO_SITE}/log/error.log
+touch ${VVV_PATH_TO_SITE}/log/access.log
+
+# Install and configure the latest stable version of WordPress
+cd ${VVV_PATH_TO_SITE}
+if ! $(wp core is-installed --allow-root); then
+  wp core download --path="${VVV_PATH_TO_SITE}" --allow-root
+  wp core config --dbname="${VVV_SITE_NAME}" --dbuser=wp --dbpass=wp --quiet --allow-root
+  wp core multisite-install --url="${VVV_SITE_NAME}.local" --quiet --title="${VVV_SITE_NAME}" --admin_name=admin --admin_email="admin@${VVV_SITE_NAME}.local" --admin_password="password" --allow-root
+else
+  wp core update --allow-root
+fi
+```
+
+This will:
+ - download, configure and install a fresh copy of WordPress, keep it up to date
+ - Make sure the PHP error logs are created
+ - Check if a database exists, if it isn't, create one and grant the needed priviledges

--- a/docs/en-US/basic-usage.md
+++ b/docs/en-US/basic-usage.md
@@ -1,0 +1,41 @@
+---
+layout: page
+title: Basic Usage
+permalink: /docs/en-US/references/basic-usage/
+---
+
+# Basic Usage
+
+## Using a GUI
+
+This documentation assumes some very basic terminal/command line knowledge to run simple commands. However, some people prefer the convenience of a visual UI. If you fall into this category then consider the [Vagrant Manager](http://vagrantmanager.com/)  project.
+
+Note: Until you provision VVV for the first time, Vagrant Manager will not pick up VVV. Running `vagrant up --provision`  inside the VVV folder and allowing it to succesfully finish should be enough.
+
+## Turning VVV On
+
+```shell
+vagrant up
+```
+
+If Vagrant triggers are installed, and the VVV machine is turned off, this will also run the provisioner.
+
+## Turning VVV Off
+
+```shell
+vagrant halt
+```
+
+This will shut down the virtual machine. If the machine is frozen for whatever reason, add the ` --force` parameter. If it still refuses to power off, open Virtualbox and manually power the VM off.
+
+## Restarting VVV
+
+```shell
+vagrant reload
+```
+
+This will do a restart of the Virtual Machine, and is the same as running `vagrant halt;vagrant up`
+
+## Reloading `vvv-custom.yml`
+
+If you make any changes to your config file, they won't take immediate effect. For changes to take hold, restart VVV using `vagrant reload --provision`

--- a/docs/en-US/built-in-wp-installs.md
+++ b/docs/en-US/built-in-wp-installs.md
@@ -1,0 +1,30 @@
+---
+layout: page
+title: Built in WordPress installs
+permalink: /docs/en-US/built-in-wordpress-installs
+---
+
+# Built in WordPress installs
+
+#### VVV as a MAMP/XAMPP Replacement
+
+Once Vagrant and VirtualBox are installed, download or clone VVV and type `vagrant up --provision` to automatically build a virtualized Ubuntu server on your computer. See our section on [The First Vagrant Up](#installation---the-first-vagrant-up) for detailed instructions.
+
+Multiple projects can be developed at once in the same environment.
+
+* Use `wp-content/themes` in either the `www/wordpress-default` or `www/wordpress-develop/src` directories to develop themes.
+* Use `wp-content/plugins` in either the `www/wordpress-default` or `www/wordpress-develop/src` directories to develop plugins.
+* Take advantage of VVV's [auto site configuration](https://github.com/varying-vagrant-vagrants/vvv/wiki/Auto-site-Setup) to provision additional instances of WordPress in `www/`. The [Variable VVV](https://github.com/bradp/vv) project helps to automate this process.
+* Use the `www/wordpress-develop` directory to participate in [WordPress core](https://make.wordpress.org/core) development.
+
+VVV's `config`, `database`, `log` and `www` directories are shared with the virtualized server.
+
+These shared directories allow you to work, for example, in `vagrant-local/www/wordpress-default` in your local file system and have those changes immediately reflected in the virtualized server's file system and http://local.wordpress.dev/. Likewise, if you `vagrant ssh` and make modifications to the files in `/srv/www/`, you'll immediately see those changes in your local file system.
+
+## Use Git instead of Subversion for WordPress core development
+
+By default, VVV provisions WordPress into `/www/wordpress-develop/` from the [WordPress Subversion repository](https://develop.svn.wordpress.org/).
+
+If you prefer to use Git, there is a [bundled script](https://github.com/Varying-Vagrant-Vagrants/VVV/blob/master/config/homebin/develop_git) that converts to using the [Git mirror](https://develop.git.wordpress.org).
+
+To enable Git for core development, use `vagrant ssh` to access the virtual machine and then run `develop_git`. Alternatively, do this in one line with: `vagrant ssh -c /srv/config/homebin/develop_git`.

--- a/docs/en-US/default-credentials.md
+++ b/docs/en-US/default-credentials.md
@@ -1,0 +1,43 @@
+---
+layout: page
+title: Default Credentials
+permalink: /docs/en-US/default-credentials
+---
+
+# Default Credentials
+
+All database usernames and passwords for WordPress installations included by default are:
+
+__User:__ `wp`
+__Password:__ `wp`
+
+All WordPress admin usernames and passwords for WordPress installations included by default are:
+
+__User:__ `admin`
+__Password:__ `password`
+
+MySQL Root:
+
+__User:__ `root`
+__Password:__ `root`
+
+See: [Connecting to MySQL](https://github.com/varying-vagrant-vagrants/vvv/wiki/Connecting-to-MySQL) from your local machine
+
+Vagrant Box Ubuntu Root:
+
+__User:__ `root`
+__Password:__ `vagrant`
+
+#### WordPress Stable
+* LOCAL PATH: vagrant-local/www/wordpress-default
+* VM PATH: /srv/www/wordpress-default
+* URL: `http://local.wordpress.dev`
+* DB Name: `wordpress_default`
+
+#### WordPress Develop
+* LOCAL PATH: vagrant-local/www/wordpress-develop
+* VM PATH: /srv/www/wordpress-develop
+* /src URL: `http://src.wordpress-develop.dev`
+* /build URL: `http://build.wordpress-develop.dev`
+* DB Name: `wordpress_develop`
+* DB Name: `wordpress_unit_tests`

--- a/docs/en-US/governance.md
+++ b/docs/en-US/governance.md
@@ -1,0 +1,85 @@
+---
+layout: page
+title: Governance
+permalink: /docs/en-US/governance/
+---
+
+## Overview
+
+The [VVV core project](https://github.com/Varying-Vagrant-Vagrants/VVV/) and its individual modules, collectively organized as [Varying Vagrant Vagrants](https://github.com/Varying-Vagrant-Vagrants/) (VVV), are governed with a [benevolent dictator governance model](http://producingoss.com/en/benevolent-dictator.html).
+
+In general, this means that VVV is maintained by a community of active contributors. Most decisions are made in this context and contributions are always welcome. The project lead performs a role of project leadership and architectural oversight.
+
+VVV is copyright the contributors of the VVV project under the [MIT License](https://github.com/Varying-Vagrant-Vagrants/VVV/blob/develop/LICENSE). A [guide to contributing](https://github.com/Varying-Vagrant-Vagrants/VVV/blob/develop/.github/CONTRIBUTING.md) is also available.
+
+## Roles and Responsibilities
+
+### Project Lead
+
+The project lead is trusted to set an overall strategic direction and, as necessary, to provide a final say in any arguments or disputes. They have full access to repositories, servers, and other services associated with project management. With the input of lead developers, they coordinate project maintenance and assign roles within the community.
+
+Current project lead:
+
+* [Jeremy Felt](https://github.com/jeremyfelt)
+
+The current project lead assumed the role as founder of the project. When they transition out of the project lead role, a steering committee will be formed of trusted stakeholders and community members. This committee will select a new project lead or leads. When this committee is formed, 10up will be offered at least one seat on that group.
+
+### Lead Developers
+
+Lead developers are trusted to make changes to all project code by merging their own pull requests and the pull requests of contributors. They have full access to all project repositories. They have the authority and ability to close issues and pull requests. As necessary, they will help in providing guidance to new contributors and committers.
+
+Current lead developers:
+
+* [Lorelei Aurora](https://github.com/lorelieaurora)
+
+Lead developers are selected by the project lead.
+
+### Committers
+
+Committers are trusted to make changes to project code by merging the pull requests of contributors. They have push access to one or more project repositories. They have the authority and ability to close issues and pull requests. Pull requests submitted by committers should be reviewed by another committer before merge. As necessary, they will help in providing guidance to new contributors.
+
+Current committers:
+
+* [Weston Ruter](https://github.com/westonruter)
+* [Tom Nowell](https://github.com/tomjn)
+* [Simon Wheatley](https://github.com/simonwheatley)
+* [Luke Woodward](https://github.com/lkwdwrd)
+* [Christian Foellman](https://github.com/cfoellmann)
+
+Contributors who [show good judgement](http://producingoss.com/en/committers.html#choosing-committers) may be selected as committers for one or more project repositories. The decision to promote a contributor to a committer will be made by consensus between the project lead and lead developers. This decision should be based on meritocratic criteria including, but not limited to, consistent and quality pull requests, bug gardening, support answers, and general community participation.
+
+### Contributors
+
+Contributors are vital to the success of open source software. VVV is fortunate to have a large community of contributors that have provided support in one way or another over the last several years. Please see the [contributing guide](https://github.com/Varying-Vagrant-Vagrants/VVV/blob/develop/.github/CONTRIBUTING.md) for information on how you can become a contributor.
+
+A list of [people who have contributed code to VVV](https://github.com/Varying-Vagrant-Vagrants/VVV/graphs/contributors) is maintained by GitHub.
+
+## Project Founders
+
+VVV is a [10up](https://10up.com) creation. [Jeremy Felt](https://jeremyfelt.com/) is the founding developer. [VVV transitioned](http://10up.com/blog/varying-vagrant-vagrants-future/) to a community organization in 2014.  The [first draft of VVV](https://jeremyfelt.com/2012/12/11/varying-vagrant-vagrants/) was released on December 11, 2012.
+
+## Project Administration
+
+### GitHub organization
+
+The [Varying Vagrant Vagrants GitHub organization](https://github.com/Varying-Vagrant-Vagrants) is owned by Jeremy Felt in that it's his email address that is assigned as the "Billing email". Lorelei Aurora's membership level is also set to "Owner". All lead developers and committers have permissions to create new repositories. The organization is currently configured under the free plan and there are no private repositories.
+
+### VVV Website
+
+The VVV website is located at [https://varyingvagrantvagrants.org](https://varyingvagrantvagrants.org).
+
+#### Domain name
+
+The `varyingvagrantvagrants.org` and `varyingvagrantvagrants.com` domains are owned by Jeremy Felt.
+
+#### Server
+
+The `varyingvagrantvagrants.org` domain is assigned to a virtual machine, hosted with Linode. That server is managed and paid for by Jeremy Felt.
+
+#### S3 account
+
+Documentation from VVV's repositories is deployed directly to an S3 bucket. That bucket is managed and paid for by Jeremy Felt.
+
+#### Google Analytics
+
+Google Analytics is used to track visitors on the `varyingvagrantvagrants.org` domain. That account is managed by Jeremy Felt.

--- a/docs/en-US/history.md
+++ b/docs/en-US/history.md
@@ -1,0 +1,13 @@
+---
+layout: page
+title: History
+permalink: /docs/en-US/history/
+---
+
+VVV is a [10up](http://10up.com) creation and [transitioned](https://10up.com/blog/varying-vagrant-vagrants-future/) to a community organization in 2014.
+
+VVV has come a long way since it was first [launched as Varying Vagrant Vagrants](https://jeremyfelt.com/code/2012/12/11/varying-vagrant-vagrants/) in December of 2012. Initially introduced as an exploration of workflow for immediate project needs at [10up](http://10up.com), VVV caught speed quickly as more and more of the team was introduced. During an internal [10up developer summit](https://10up.com/blog/10up-2013-developer-summit/) in March of 2013, Vagrant as a tool was a highlight and more developers made the conversion.
+
+In April of 2013, we made a [call to the WordPress community](https://jeremyfelt.com/code/2013/04/08/hi-wordpress-meet-vagrant/) to try to encourage the addition of Vagrant to everyday life. These efforts continued with talks at [WordCamp Chicago](https://wordpress.tv/2013/12/31/jeremy-felt-hi-wordpress-meet-vagrant-2/), [WordCamp Vancouver](https://wordpress.tv/2013/10/19/jeremy-felt-hi-wordpress-meet-vagrant/), and WordCamp Denver.
+
+In January of 2014, [10up](https://10up.com) made the decision to [spin VVV off](https://10up.com/blog/varying-vagrant-vagrants-future/) into its own organization to better align with the community that has grown around the project over time. This transition opens doors for what [Varying Vagrant Vagrants, the organization](https://jeremyfelt.com/code/2014/01/27/varying-vagrant-vagrants-organization/) can accomplish as an ongoing project.

--- a/docs/en-US/index.md
+++ b/docs/en-US/index.md
@@ -1,0 +1,56 @@
+---
+layout: page
+title: VVV 2.0.0 Documentation
+permalink: /docs/en-US/
+---
+
+## Getting Started
+
+These guides are intended to help with the initial installation of VVV as well as to provide ongoing support as you get familiar with its configuration.
+
+* [Installing VVV 2](installation.md)
+* [Add New Sites](adding-a-new-site/index.md)
+   * [Changing a sites PHP Version](adding-a-new-site/changing-php-version.md)
+   * [Custom Domains and Hosts](adding-a-new-site/custom-domains-hosts.md)
+   * [Custom Paths and Folders](adding-a-new-site/custom-paths-and-folders.md)
+   * [Nginx Configs](adding-a-new-site/nginx-configs.md)
+   * [Setup Scripts](adding-a-new-site/setup-script.md)
+* [Migrating from VVV1](migrating-vvv1.md)
+* [Utilities](utilities.md)
+* [Troubleshooting](troubleshooting.md)
+* [Guide to vvv-custom.yml](vvv-config.yml.md)
+* [History](history.md)
+* [Governance](governance.md)
+
+## Reference documents
+
+* [Default credentials](references/default-credentials.md) is a list of the default usernames and passwords provsioned in VVV.
+* [PHP Extensions](references/php-extensions.md) is a list of the PHP extensions provisioned by default.
+* [Installed packages](references/installed-packages.md) is a list of packages installed during default provisioning.
+* [Default sites](references/default-sites.md) installed with VVV.
+* [Basic usage](references/basic-usage.md) provides the basics of using Vagrant to manage a VM.
+
+## Help
+
+* [Troubleshooting](troubleshooting.md)
+* [Migrating from VVV 1 to 2](migrating-vvv1.md)
+
+## Helpful Extensions
+
+Support for custom init scripts and site configurations allows for some great extensions of VVV core.
+
+* [Variable VVV](https://github.com/bradp/vv) automates setting up new sites, setting up deployments, and more.
+* [WordPress Meta Environment](https://github.com/WordPress/meta-environment) is a "collection of scripts that provision the official WordPress.org websites into a Varying Vagrant Vagrants installation."
+
+## Custom Dashboards
+
+The dashboard provided by VVV allows for easy replacement by looking for a `www/default/dashboard-custom.php` file. The community has built several great dashboards that may be more useful than the bare info provided by default:
+
+* @topdown's [VVV Dashboard](https://github.com/topdown/VVV-Dashboard)
+* @leogopal's [VVV Dashboard](https://github.com/leogopal/VVV-Dashboard)
+* @stevenkword's [VVV Dashboard Custom](https://github.com/stevenkword/vvv-dashboard-custom)
+* @goblindegook's [VVV Material Dashboard](https://github.com/goblindegook/vvv-material-dashboard)
+
+## Copyright / License
+
+VVV is copyright (c), the contributors of the VVV project under the [MIT License](LICENSE).

--- a/docs/en-US/installation.md
+++ b/docs/en-US/installation.md
@@ -1,0 +1,45 @@
+---
+layout: page
+title: Installation
+permalink: /docs/en-US/installation/
+---
+
+## The first "vagrant up"
+
+1. Install [VirtualBox 5.x](https://www.virtualbox.org/wiki/Downloads)
+1. Install [Vagrant 1.x](https://www.vagrantup.com/downloads.html)
+    * `vagrant` will now be available as a command in your terminal, try it out.
+    * ***Note:*** If Vagrant is already installed, use `vagrant -v` to check the version. You may want to consider upgrading if a much older version is in use.
+1. Install some these Vagrant plugins:
+    1. Install the [vagrant-hostsupdater](https://github.com/cogitatio/vagrant-hostsupdater) plugin with `vagrant plugin install vagrant-hostsupdater`
+    1. Install the [vagrant-triggers](https://github.com/emyl/vagrant-triggers) plugin with `vagrant plugin install vagrant-triggers`
+        * Triggers allows for various scripts to fire when issuing commands such as `vagrant halt` and `vagrant destroy`. a `db_backup` script will run on halt, suspend, and destroy that backs up each database to a `dbname.sql` file in the `{vvv}/database/backups/` directory. These will then be imported automatically if starting from scratch. Custom scripts can be added to override this default behavior.
+1. Clone or extract the Varying Vagrant Vagrants project into a local directory
+    * `git clone -b master git://github.com/Varying-Vagrant-Vagrants/VVV.git vagrant-local`
+    * OR download and extract a [stable release](https://github.com/varying-vagrant-vagrants/vvv/releases) zip or tar.
+1. In a terminal, change into the new directory with `cd vagrant-local` and type `vagrant up` to start VVV.
+	* For Windows 8 or higher it is recommended that you run the cmd window as Administrator.
+    * Be patient as the magic happens. This could take a while on the first run as your local machine downloads the required files.
+    * Watch as the virtual machine starts. Your machine ***password may be required*** to properly modify the hosts file on your local machine.
+1. Visit any of the [built in WordPress sites](references/default-sites.md) or the VVV Dashboard at [http://vvv.dev](http://vvv.dev)
+
+## What did that do?
+
+The first time you run `vagrant up`, a packaged box containing a basic virtual machine is downloaded to your local machine and cached for future use. The file used by Varying Vagrant Vagrants contains an installation of Ubuntu 14.04 and is about 332MB.
+
+After this box is downloaded, it begins to boot as a sandboxed virtual machine using VirtualBox. Once booted, it runs the provisioning script included with VVV. This initiates the download and installation of around 100MB of packages on the new virtual machine.
+
+The time for all of this to happen depends a lot on the speed of your Internet connection. If you are on a fast cable connection, it will likely only take several minutes.
+
+On future runs of `vagrant up`, the packaged box will be cached on your local machine and Vagrant will only need to apply the requested provisioning.
+
+## And now what?
+
+Now that you're up and running, start poking around and modifying things.
+
+* Access the server via the command line with `vagrant ssh` from your `vagrant-local` directory. You can do almost anything you would do with a standard Ubuntu installation on a full server.
+    * **MS Windows users:** An SSH client is generally not distributed with Windows PCs by default. However, a terminal emulator such as [PuTTY](http://www.chiark.greenend.org.uk/~sgtatham/putty/download.html) will provide access immediately. For detailed instructions on connecting with PuTTY, consult the [VVV Wiki](https://github.com/Varying-Vagrant-Vagrants/VVV/wiki/Connect-to-Your-Vagrant-Virtual-Machine-with-PuTTY).
+* Power off the box with `vagrant halt` and turn it back on with `vagrant up`.
+* Reapply provisioning to a running box with `vagrant provision`.
+* Destroy the box with `vagrant destroy`. Any data stored in the virtual machine, including databases, will be deleted. Files added in the `www` directory will persist on the next `vagrant up`.
+* Start modifying and adding local files to fit your needs. Take a look at [Adding a Site](adding-a-new-site/index.md) for tips on adding new projects.

--- a/docs/en-US/installation/index.md
+++ b/docs/en-US/installation/index.md
@@ -1,0 +1,61 @@
+---
+layout: page
+title: Installation
+permalink: /docs/en-US/installation/
+---
+
+# Installation
+
+1. Start with any local operating system such as Mac OS X, Linux, or Windows.
+    * For Windows 8 or higher it is recommended that you run the cmd window as Administrator
+1. Install [VirtualBox 5.x](https://www.virtualbox.org/wiki/Downloads)
+1. Install [Vagrant 1.x](https://www.vagrantup.com/downloads.html)
+    * `vagrant` will now be available as a command in your terminal, try it out.
+    * ***Note:*** If Vagrant is already installed, use `vagrant -v` to check the version. You may want to consider upgrading if a much older version is in use.
+1. Install some these Vagrant plugins:
+    1. Install the [vagrant-hostsupdater](https://github.com/cogitatio/vagrant-hostsupdater) plugin with `vagrant plugin install vagrant-hostsupdater`
+        * Note: This step is not a requirement, though it does make the process of starting up a virtual machine nicer by automating the entries needed in your local machine's `hosts` file to access the provisioned VVV domains in your browser.
+        * If you choose not to install this plugin, a manual entry should be added to your local `hosts` file that looks like this: `192.168.50.4  vvv.dev local.wordpress.dev src.wordpress-develop.dev build.wordpress-develop.dev`
+    1. Install the [vagrant-triggers](https://github.com/emyl/vagrant-triggers) plugin with `vagrant plugin install vagrant-triggers`
+        * Note: This step is not a requirement. When installed, it allows for various scripts to fire when issuing commands such as `vagrant halt` and `vagrant destroy`.
+        * By default, if vagrant-triggers is installed, a `db_backup` script will run on halt, suspend, and destroy that backs up each database to a `dbname.sql` file in the `{vvv}/database/backups/` directory. These will then be imported automatically if starting from scratch. Custom scripts can be added to override this default behavior.
+        * If vagrant-triggers is not installed, VVV will not provide automated database backups.
+    1. Install the [vagrant-vbguest](https://github.com/dotless-de/vagrant-vbguest) plugin with `vagrant plugin install vagrant-vbguest`.
+        * Note: This step is not a requirement. When installed, it keeps the [VirtualBox Guest Additions](https://www.virtualbox.org/manual/ch04.html) kernel modules of your guest synchronized with the version of your host whenever you do `vagrant up`. This can prevent some subtle shared folder errors.
+1. Clone or extract the Varying Vagrant Vagrants project into a local directory
+    * `git clone -b master git://github.com/Varying-Vagrant-Vagrants/VVV.git vagrant-local`
+    * OR download and extract the repository `develop` branch [zip file](https://github.com/varying-vagrant-vagrants/vvv/archive/develop.zip) to a `vagrant-local` directory on your computer.
+    * OR download and extract a [stable release](https://github.com/varying-vagrant-vagrants/vvv/releases) zip file if you'd like some extra comfort.
+1. In a command prompt, change into the new directory with `cd vagrant-local`
+1. Start the Vagrant environment with `vagrant up`
+    * Be patient as the magic happens. This could take a while on the first run as your local machine downloads the required files.
+    * Watch as the script ends, as an administrator or `su` ***password may be required*** to properly modify the hosts file on your local machine.
+1. Visit any of the [built in WordPress sites](built-in-wp-installs.md) or the VVV Dashboard at [http://vvv.dev](http://vvv.dev)
+
+Fancy, yeah?
+
+## What Did That Do?
+
+The first time you run `vagrant up`, a packaged box containing a basic virtual machine is downloaded to your local machine and cached for future use. The file used by Varying Vagrant Vagrants contains an installation of Ubuntu 14.04 and is about 332MB.
+
+After this box is downloaded, it begins to boot as a sandboxed virtual machine using VirtualBox. Once booted, it runs the provisioning script included with VVV. This initiates the download and installation of around 100MB of packages on the new virtual machine.
+
+The time for all of this to happen depends a lot on the speed of your Internet connection. If you are on a fast cable connection, it will likely only take several minutes.
+
+On future runs of `vagrant up`, the packaged box will be cached on your local machine and Vagrant will only need to apply the requested provisioning.
+
+* ***Preferred:*** If the virtual machine has been powered off with `vagrant halt`, `vagrant up` will quickly power on the machine without provisioning.
+* ***Rare:*** If you would like to reapply the provisioning scripts with `vagrant up --provision` or `vagrant provision`, some time will be taken to check for updates and packages that have not been installed.
+* ***Very Rare:*** If the virtual machine has been destroyed with `vagrant destroy`, it will need to download the full 100MB of package data on the next `vagrant up`.
+
+## Now What?
+
+Now that you're up and running, start poking around and modifying things.
+
+1. Access the server via the command line with `vagrant ssh` from your `vagrant-local` directory. You can do almost anything you would do with a standard Ubuntu installation on a full server.
+    * **MS Windows users:** An SSH client is generally not distributed with Windows PCs by default. However, a terminal emulator such as [PuTTY](http://www.chiark.greenend.org.uk/~sgtatham/putty/download.html) will provide access immediately. For detailed instructions on connecting with PuTTY, consult the [VVV Wiki](https://github.com/Varying-Vagrant-Vagrants/VVV/wiki/Connect-to-Your-Vagrant-Virtual-Machine-with-PuTTY).
+1. Power off the box with `vagrant halt` and turn it back on with `vagrant up`.
+1. Suspend the box's state in memory with `vagrant suspend` and bring it right back with `vagrant resume`.
+1. Reapply provisioning to a running box with `vagrant provision`.
+1. Destroy the box with `vagrant destroy`. Files added in the `www` directory will persist on the next `vagrant up`.
+1. Start modifying and adding local files to fit your needs. Take a look at [Adding a Site](adding-a-new-site/index.md) for tips on adding new projects.

--- a/docs/en-US/installation/software-requirements.md
+++ b/docs/en-US/installation/software-requirements.md
@@ -1,0 +1,13 @@
+---
+layout: page
+title: Software Requirements
+permalink: /docs/en-US/installation/software-requirements
+---
+
+# Software Requirements
+
+VVV requires recent versions of both Vagrant and VirtualBox to be installed.
+
+[Vagrant](https://www.vagrantup.com) is a "tool for building and distributing development environments". It works with [virtualization](https://en.wikipedia.org/wiki/X86_virtualization) software such as [VirtualBox](https://www.virtualbox.org/) to provide a virtual machine sandboxed from your local environment.
+
+Provider support is included for VirtualBox, Parallels, Hyper-V, VMWare Fusion, and VMWare Workstation.

--- a/docs/en-US/migrating-vvv1.md
+++ b/docs/en-US/migrating-vvv1.md
@@ -1,0 +1,81 @@
+---
+layout: page
+title: Migrate VVV 1.4.x to 2.0.0
+permalink: /docs/en-US/migrate-vvv-1/
+---
+
+## Overview
+
+Sites configured in VVV 1.4.x and earlier require additional setup after upgrading to VVV 2.0.0. For best results, a complete `vagrant destroy` is recommended, but a migration without data loss is still possible. Please be sure to backup critical files and databases.
+
+A full provision should be run at least once during this process.
+
+If you'd like, run `vagrant provision` before making the changes to configuration described in this document. This will ensure that core packages are updated and allow you to use `vagrant provision --provision-with` for individual sites. You can also wait until custom sites have been configured before running a full `vagrant provision` to handle everything at once.
+
+## Preparation
+
+The `vvv-config.yml` (default) or `vvv-custom.yml` (custom) configuration files are used by VVV to discover sites. Adding existing sites to one of these files will allow VVV to see and provision them.
+
+First, copy the default `vvv-config.yml` file to `vvv-custom.yml`. This creates a custom configuration and keeps the VVV repository clear for future changes.
+
+## Migrate a custom site
+
+The sites configured in `vvv-custom.yml` map directly to project directories in `vvv/www/`. If, for example, a custom site's files are in `vvv/www/my-test-site`, migrate it from 1.4.x to 2.0.0 by adding `my-test-site:` to the `sites` section of `vvv-custom.yml`:
+
+```YAML
+sites:
+  # Full default configuration clipped for length.
+
+  my-test-site:
+
+utilities:
+  core:
+    - memcached-admin
+```
+
+Now `vagrant provision` or `vagrant provision --provision-with site-my-test-site` will process the `vvv-init.sh`, `vvv-nginx.conf`, and `vvv-hosts` files in the custom site's directory, `vvv/www/my-test-site/`.
+
+### Using a git repository
+
+If the `my-test-site` project also exists as a git repository with `vvv-init.sh`, `vvv-nginx.conf`, and `vvv-hosts` files, this can also be configured.
+
+```YAML
+sites:
+  # Full default configuration clipped for length.
+
+  my-test-site: https://github.com/username/my-test-site.git
+
+utilities:
+  core:
+    - memcached-admin
+```
+
+This will cause any changes to be pulled from the repository when `vagrant provision` or `vagrant provision --provision-with site-my-test-site` is run.
+
+See the [full YAML configuration documentation](vvv-config.yml.md) for details on other available options.
+
+## Migrate a default site
+
+VVV 1.4.x provides a handful of sites by default. These sites were provisioned directly by VVV and do not have the necessary structure for the migration used with custom sites.
+
+The easiest route will be to delete the `vvv/www/wordpress-develop` and `vvv/www/wordpress-default` directories. Be sure to back up any crucial files in these directories beforehand.
+
+Once these directories are deleted, run `vagrant provision` or `vagrant provision --provision-with site-wordpress-develop` and `vagrant provision --provision-with site-wordpress-default`. The configuration in the `vvv-config.yml` or `vvv-custom.yml` files will provide the provisioner with the information it needs to reconfigure these sites using the same databases as before.
+
+## Custom sites in non-standard folders
+
+Some sites are in nested or non-standard folder structures. See the [custom paths and folders](adding-a-new-site/custom-paths-and-folders.md) documentation for how to configure these sites.
+
+## Why is this necessary?
+
+VVV sites work the same way in 1.4.x and 2.0.0, but with one major difference. VVV 2.0.0 uses a YAML configuration file, and VVV 1.4.x scanned for sites automatically.
+
+### How 1.4.x detected sites
+
+When the 1.4.x provisioner ran, it scanned the contents of the entire VVV folder for `vvv-init.sh` and `vvv-nginx.conf` files. As a result, VVV picked up sites regardless of location, even catching nested sites.
+
+Among other things, this caused performance problems. Folder scans could be very slow with some file systems, and there was no way to control which sites were provisioned. If you wanted to provision a site quickly, larger sites had to be moved out of the `www` folder.
+
+### How 2.0.0 detects sites
+
+VVV 2.0.0 does away with site auto-detection. Instead VVV uses a YAML configuration file named `vvv-config.yml` (default) or `vvv-custom.yml` (custom) that lists all sites. A series of options are available to customize the environment and location of each site. This makes provisioning significantly faster, allowing for the provisioning of individual sites or the entire VM.

--- a/docs/en-US/php-extensions.md
+++ b/docs/en-US/php-extensions.md
@@ -1,0 +1,66 @@
+---
+layout: page
+title: PHP Extensions
+permalink: /docs/en-US/references/php-extensions
+---
+
+This page lists all the PHP Modules bundled with VVV.
+
+PHP & all modules listed below are installed from [this PPA](https://launchpad.net/~ondrej/+archive/ubuntu/php) maintained by  
+[Ondřej Surý](https://github.com/oerdnj)
+
+| Module                                                     | Provided By Package |
+|------------------------------------------------------------|---------------------|
+| [bcmath](http://php.net/manual/en/book.bcmath.php)         | php7.0-bcmath       |
+| [calendar](http://php.net/manual/en/book.calendar.php)     | php7.0-common       |
+| cgi-fcgi                                                   | php7.0-fpm          |
+| Core                                                       | php7.0-common       |
+| [ctype](http://php.net/manual/en/book.ctype.php)           | php7.0-common       |
+| [curl](http://php.net/manual/en/book.curl.php)             | php7.0-curl         |
+| date                                                       | php7.0-common       |
+| [dom](http://php.net/manual/en/book.dom.php)               | php7.0-xml          |
+| [exif](http://php.net/manual/en/book.exif.php)             | php7.0-common       |
+| [fileinfo](http://php.net/manual/en/book.fileinfo.php)     | php7.0-common       |
+| [filter](http://php.net/manual/en/book.filter.php)         | php7.0-common       |
+| [ftp](http://php.net/manual/en/book.ftp.php)               | php7.0-common       |
+| [gd](http://php.net/manual/en/book.image.php)              | php7.0-gd           |
+| [gettext](http://php.net/manual/en/book.gettext.php)       | php7.0-common       |
+| [hash](http://php.net/manual/en/book.hash.php)             | php7.0-common       |
+| [iconv](http://php.net/manual/en/book.iconv.php)           | php7.0-common       |
+| [imagick](http://php.net/manual/en/book.imagick.php)       | php-imagick         |
+| [imap](http://php.net/manual/en/book.imap.php)             | php7.0-imap         |
+| [json](http://php.net/manual/en/book.json.php)             | php7.0-json         |
+| [libxml](http://php.net/manual/en/book.libxml.php)         | php7.0-common       |
+| [mbstring](http://php.net/manual/en/book.mbstring.php)     | php7.0-mbstring     |
+| [mcrypt](http://php.net/manual/en/book.mcrypt.php)         | php7.0-mcrypt       |
+| [memcache](http://php.net/manual/en/book.memcache.php)     | php-memcache        |
+| [mysqli](http://php.net/manual/en/book.mysqli.php)         | php7.0-mysql        |
+| [mysqlnd](http://php.net/manual/en/book.mysqlnd.php)       | php7.0-mysql        |
+| [openssl](http://php.net/manual/en/book.openssl.php)       | php7.0-common       |
+| [pcre](http://php.net/manual/en/book.pcre.php)             | php7.0-common       |
+| [PDO](http://php.net/manual/en/book.pdo.php)               | php7.0-common       |
+| [pdo_mysql](http://php.net/manual/en/ref.pdo-mysql.php)    | php7.0-mysql        |
+| [Phar](http://php.net/manual/en/book.phar.php)             | php7.0-common       |
+| [posix](http://php.net/manual/en/book.posix.php)           | php7.0-common       |
+| [readline](http://php.net/manual/en/book.readline.php)     | php7.0-readline     |
+| [Reflection](http://php.net/manual/en/book.reflection.php) | php7.0-common       |
+| [session](http://php.net/manual/en/book.session.php)       | php7.0-common       |
+| [shmop](http://php.net/manual/en/book.shmop.php)           | php7.0-common       |
+| [SimpleXML](http://php.net/manual/en/book.simplexml.php)   | php7.0-xml          |
+| [soap](http://php.net/manual/en/book.soap.php)             | php7.0-soap         |
+| [sockets](http://php.net/manual/en/book.sockets.php)       | php7.0-common       |
+| [SPL](http://php.net/manual/en/book.spl.php)               | php7.0-common       |
+| [ssh2](http://php.net/manual/en/book.ssh2.php)             | php-ssh2            |
+| standard                                                   | php7.0-common       |
+| [sysvmsg](http://php.net/manual/en/book.sem.php)           | php7.0-common       |
+| [sysvsem](http://php.net/manual/en/book.sem.php)           | php7.0-common       |
+| [sysvshm](http://php.net/manual/en/book.sem.php)           | php7.0-common       |
+| [tokenizer](http://php.net/manual/en/book.tokenizer.php)   | php7.0-common       |
+| [wddx](http://php.net/manual/en/book.wddx.php)             | php7.0-xml          |
+| [xml](http://php.net/manual/en/book.xml.php)               | php7.0-xml          |
+| [xmlreader](http://php.net/manual/en/book.xmlreader.php)   | php7.0-xml          |
+| [xmlwriter](http://php.net/manual/en/book.xmlwriter.php)   | php7.0-xml          |
+| [xsl](http://php.net/manual/en/book.xsl.php)               | php7.0-xml          |
+| [Zend OPcache](http://php.net/manual/en/book.opcache.php)  | php7.0-opcache      |
+| [zip](http://php.net/manual/en/book.zip.php)               | php7.0-zip          |
+| [zlib](http://php.net/manual/en/book.zlib.php)             | php7.0-common       |

--- a/docs/en-US/references/basic-usage.md
+++ b/docs/en-US/references/basic-usage.md
@@ -1,0 +1,46 @@
+---
+layout: page
+title: Basic Usage
+permalink: /docs/en-US/references/basic-usage/
+---
+
+* [Basic usage](basic-usage.md) provides the basics of using Vagrant to manage a VM.
+* [Default credentials](default-credentials.md) is a list of the default usernames and passwords provsioned in VVV.
+* [Default sites](default-sites.md) installed with VVV.
+* [Installed packages](installed-packages.md) is a list of packages installed during default provisioning.
+* [PHP Extensions](php-extensions.md) is a list of the PHP extensions provisioned by default.
+
+
+## Using a GUI
+
+This documentation assumes some very basic terminal/command line knowledge to run simple commands. However, some people prefer the convenience of a visual UI. If you fall into this category then consider the [Vagrant Manager](http://vagrantmanager.com/)  project.
+
+Note: Until you provision VVV for the first time, Vagrant Manager will not pick up VVV. Running `vagrant up --provision`  inside the VVV folder and allowing it to successfully finish should be enough.
+
+## Turning VVV On
+
+```shell
+vagrant up
+```
+
+If Vagrant triggers are installed, and the VVV machine is turned off, this will also run the provisioner.
+
+## Turning VVV Off
+
+```shell
+vagrant halt
+```
+
+This will shut down the virtual machine. If the machine is frozen for whatever reason, add the ` --force` parameter. If it still refuses to power off, open VirtualBox and manually power the VM off.
+
+## Restarting VVV
+
+```shell
+vagrant reload
+```
+
+This will do a restart of the Virtual Machine, and is the same as running `vagrant halt; vagrant up`
+
+## Reloading `vvv-custom.yml`
+
+If you make any changes to your config file, they won't take immediate effect. For changes to take hold, restart VVV using `vagrant reload --provision`

--- a/docs/en-US/references/default-credentials.md
+++ b/docs/en-US/references/default-credentials.md
@@ -1,0 +1,47 @@
+---
+layout: page
+title: Default Credentials
+permalink: /docs/en-US/default-credentials/
+---
+
+* [Basic usage](basic-usage.md) provides the basics of using Vagrant to manage a VM.
+* [Default credentials](default-credentials.md) is a list of the default usernames and passwords provsioned in VVV.
+* [Default sites](default-sites.md) installed with VVV.
+* [Installed packages](installed-packages.md) is a list of packages installed during default provisioning.
+* [PHP Extensions](php-extensions.md) is a list of the PHP extensions provisioned by default.
+
+All database usernames and passwords for WordPress installations included by default are:
+
+__User:__ `wp`
+__Password:__ `wp`
+
+All WordPress admin usernames and passwords for WordPress installations included by default are:
+
+__User:__ `admin`
+__Password:__ `password`
+
+MySQL Root:
+
+__User:__ `root`
+__Password:__ `root`
+
+See: [Connecting to MariaDB/MySQL](https://github.com/Varying-Vagrant-Vagrants/VVV/wiki/Connecting-to-MySQL-MariaDB) from your local machine
+
+Vagrant Box Ubuntu Root:
+
+__User:__ `root`
+__Password:__ `vagrant`
+
+#### WordPress Stable
+* LOCAL PATH: vagrant-local/www/wordpress-default
+* VM PATH: /srv/www/wordpress-default
+* URL: `http://local.wordpress.dev`
+* DB Name: `wordpress_default`
+
+#### WordPress Develop
+* LOCAL PATH: vagrant-local/www/wordpress-develop
+* VM PATH: /srv/www/wordpress-develop
+* /src URL: `http://src.wordpress-develop.dev`
+* /build URL: `http://build.wordpress-develop.dev`
+* DB Name: `wordpress_develop`
+* DB Name: `wordpress_unit_tests`

--- a/docs/en-US/references/default-sites.md
+++ b/docs/en-US/references/default-sites.md
@@ -1,0 +1,34 @@
+---
+layout: page
+title: Default sites configured in VVV
+permalink: /docs/en-US/references/default-sites/
+---
+
+* [Basic usage](basic-usage.md) provides the basics of using Vagrant to manage a VM.
+* [Default credentials](default-credentials.md) is a list of the default usernames and passwords provsioned in VVV.
+* [Default sites](default-sites.md) installed with VVV.
+* [Installed packages](installed-packages.md) is a list of packages installed during default provisioning.
+* [PHP Extensions](php-extensions.md) is a list of the PHP extensions provisioned by default.
+
+## What are the Default Sites?
+
+VVV creates and sets up several WordPress installs for you automatically, these are:
+
+ - [http://local.wordpress.dev](http://local.wordpress.dev) - a standard WordPress install
+ - [http://src.wordpress-develop.dev](http://src.wordpress-develop.dev) and [http://build.wordpress-develop.dev](http://build.wordpress-develop.dev) - a copy of the develop branch of WordPress
+
+You can see these in your VVV config, allowing you to make new sites, or remove the built in sites if you so choose.
+
+## VVV as a MAMP/XAMPP Replacement
+
+Multiple projects can be developed at once in the same environment.
+
+* Use `wp-content/themes` in either the `www/wordpress-default` or `www/wordpress-develop/src` directories to develop themes.
+* Use `wp-content/plugins` in either the `www/wordpress-default` or `www/wordpress-develop/src` directories to develop plugins.
+* Take advantage of VVV's [auto site configuration](https://github.com/varying-vagrant-vagrants/vvv/wiki/Auto-site-Setup) to provision additional instances of WordPress in `www/`. The [Variable VVV](https://github.com/bradp/vv) project helps to automate this process.
+* Use the `www/wordpress-develop` directory to participate in [WordPress core](https://make.wordpress.org/core) development.
+
+VVV's `config`, `database`, `log` and `www` directories are shared with the virtualized server.
+
+These shared directories allow you to work, for example, in `vagrant-local/www/wordpress-default` in your local file system and have those changes immediately reflected in the virtualized server's file system and http://local.wordpress.dev/. Likewise, if you `vagrant ssh` and make modifications to the files in `/srv/www/`, you'll immediately see those changes in your local file system.
+

--- a/docs/en-US/references/installed-packages.md
+++ b/docs/en-US/references/installed-packages.md
@@ -1,0 +1,39 @@
+---
+layout: page
+title: Packages installed in VVV
+permalink: /docs/en-US/installed-packages/
+---
+
+* [Basic usage](basic-usage.md) provides the basics of using Vagrant to manage a VM.
+* [Default credentials](default-credentials.md) is a list of the default usernames and passwords provsioned in VVV.
+* [Default sites](default-sites.md) installed with VVV.
+* [Installed packages](installed-packages.md) is a list of packages installed during default provisioning.
+* [PHP Extensions](php-extensions.md) is a list of the PHP extensions provisioned by default.
+
+These packages are installed by default in VVV:
+
+1. [Ubuntu](http://www.ubuntu.com/) 14.04 LTS (Trusty Tahr)
+1. [WordPress Develop](https://develop.svn.wordpress.org/trunk/)
+1. [WordPress Stable](https://wordpress.org/)
+1. [WP-CLI](http://wp-cli.org/) (master branch)
+1. [nginx](http://nginx.org/) ([mainline](http://nginx.com/blog/nginx-1-6-1-7-released/) version)
+1. [MariaDB](https://mariadb.org/) 10.1
+1. [php-fpm](http://php-fpm.org/) 7.0.x
+1. [memcached](http://memcached.org/)
+1. PHP [memcache extension](https://pecl.php.net/package/memcache)
+1. PHP [xdebug extension](https://pecl.php.net/package/xdebug/)
+1. PHP [imagick extension](https://pecl.php.net/package/imagick/)
+1. [PHPUnit](https://phpunit.de/)
+1. [ack-grep](http://beyondgrep.com/)
+1. [git](http://git-scm.com/)
+1. [subversion](https://subversion.apache.org/)
+1. [ngrep](http://ngrep.sourceforge.net/usage.html)
+1. [dos2unix](http://dos2unix.sourceforge.net/)
+1. [Composer](https://github.com/composer/composer)
+1. [phpMemcachedAdmin](https://code.google.com/p/phpmemcacheadmin/)
+1. [phpMyAdmin](http://www.phpmyadmin.net/) (multi-language)
+1. [Opcache Status](https://github.com/rlerdorf/opcache-status)
+1. [Webgrind](https://github.com/jokkedk/webgrind)
+1. [NodeJs](https://nodejs.org/)
+1. [grunt-cli](https://github.com/gruntjs/grunt-cli)
+1. [Mailcatcher](http://mailcatcher.me/)

--- a/docs/en-US/references/php-extensions.md
+++ b/docs/en-US/references/php-extensions.md
@@ -1,0 +1,72 @@
+---
+layout: page
+title: PHP Extensions
+permalink: /docs/en-US/references/php-extensions/
+---
+
+* [Basic usage](basic-usage.md) provides the basics of using Vagrant to manage a VM.
+* [Default credentials](default-credentials.md) is a list of the default usernames and passwords provsioned in VVV.
+* [Default sites](default-sites.md) installed with VVV.
+* [Installed packages](installed-packages.md) is a list of packages installed during default provisioning.
+* [PHP Extensions](php-extensions.md) is a list of the PHP extensions provisioned by default.
+
+This page lists all the PHP Modules bundled with VVV.
+
+PHP & all modules listed below are installed from [this PPA](https://launchpad.net/~ondrej/+archive/ubuntu/php) maintained by  
+[Ondřej Surý](https://github.com/oerdnj)
+
+| Module                                                     | Provided By Package |
+|------------------------------------------------------------|---------------------|
+| [bcmath](http://php.net/manual/en/book.bcmath.php)         | php7.0-bcmath       |
+| [calendar](http://php.net/manual/en/book.calendar.php)     | php7.0-common       |
+| cgi-fcgi                                                   | php7.0-fpm          |
+| Core                                                       | php7.0-common       |
+| [ctype](http://php.net/manual/en/book.ctype.php)           | php7.0-common       |
+| [curl](http://php.net/manual/en/book.curl.php)             | php7.0-curl         |
+| date                                                       | php7.0-common       |
+| [dom](http://php.net/manual/en/book.dom.php)               | php7.0-xml          |
+| [exif](http://php.net/manual/en/book.exif.php)             | php7.0-common       |
+| [fileinfo](http://php.net/manual/en/book.fileinfo.php)     | php7.0-common       |
+| [filter](http://php.net/manual/en/book.filter.php)         | php7.0-common       |
+| [ftp](http://php.net/manual/en/book.ftp.php)               | php7.0-common       |
+| [gd](http://php.net/manual/en/book.image.php)              | php7.0-gd           |
+| [gettext](http://php.net/manual/en/book.gettext.php)       | php7.0-common       |
+| [hash](http://php.net/manual/en/book.hash.php)             | php7.0-common       |
+| [iconv](http://php.net/manual/en/book.iconv.php)           | php7.0-common       |
+| [imagick](http://php.net/manual/en/book.imagick.php)       | php-imagick         |
+| [imap](http://php.net/manual/en/book.imap.php)             | php7.0-imap         |
+| [json](http://php.net/manual/en/book.json.php)             | php7.0-json         |
+| [libxml](http://php.net/manual/en/book.libxml.php)         | php7.0-common       |
+| [mbstring](http://php.net/manual/en/book.mbstring.php)     | php7.0-mbstring     |
+| [mcrypt](http://php.net/manual/en/book.mcrypt.php)         | php7.0-mcrypt       |
+| [memcache](http://php.net/manual/en/book.memcache.php)     | php-memcache        |
+| [mysqli](http://php.net/manual/en/book.mysqli.php)         | php7.0-mysql        |
+| [mysqlnd](http://php.net/manual/en/book.mysqlnd.php)       | php7.0-mysql        |
+| [openssl](http://php.net/manual/en/book.openssl.php)       | php7.0-common       |
+| [pcre](http://php.net/manual/en/book.pcre.php)             | php7.0-common       |
+| [PDO](http://php.net/manual/en/book.pdo.php)               | php7.0-common       |
+| [pdo_mysql](http://php.net/manual/en/ref.pdo-mysql.php)    | php7.0-mysql        |
+| [Phar](http://php.net/manual/en/book.phar.php)             | php7.0-common       |
+| [posix](http://php.net/manual/en/book.posix.php)           | php7.0-common       |
+| [readline](http://php.net/manual/en/book.readline.php)     | php7.0-readline     |
+| [Reflection](http://php.net/manual/en/book.reflection.php) | php7.0-common       |
+| [session](http://php.net/manual/en/book.session.php)       | php7.0-common       |
+| [shmop](http://php.net/manual/en/book.shmop.php)           | php7.0-common       |
+| [SimpleXML](http://php.net/manual/en/book.simplexml.php)   | php7.0-xml          |
+| [soap](http://php.net/manual/en/book.soap.php)             | php7.0-soap         |
+| [sockets](http://php.net/manual/en/book.sockets.php)       | php7.0-common       |
+| [SPL](http://php.net/manual/en/book.spl.php)               | php7.0-common       |
+| [ssh2](http://php.net/manual/en/book.ssh2.php)             | php-ssh2            |
+| standard                                                   | php7.0-common       |
+| [sysvmsg](http://php.net/manual/en/book.sem.php)           | php7.0-common       |
+| [sysvsem](http://php.net/manual/en/book.sem.php)           | php7.0-common       |
+| [sysvshm](http://php.net/manual/en/book.sem.php)           | php7.0-common       |
+| [tokenizer](http://php.net/manual/en/book.tokenizer.php)   | php7.0-common       |
+| [wddx](http://php.net/manual/en/book.wddx.php)             | php7.0-xml          |
+| [xml](http://php.net/manual/en/book.xml.php)               | php7.0-xml          |
+| [xmlreader](http://php.net/manual/en/book.xmlreader.php)   | php7.0-xml          |
+| [xmlwriter](http://php.net/manual/en/book.xmlwriter.php)   | php7.0-xml          |
+| [xsl](http://php.net/manual/en/book.xsl.php)               | php7.0-xml          |
+| [Zend OPcache](http://php.net/manual/en/book.opcache.php)  | php7.0-opcache      |
+| [zip](http://php.net/manual/en/book.zip.php)               | php7.0-zip          |
+| [zlib](http://php.net/manual/en/book.zlib.php)             | php7.0-common       |

--- a/docs/en-US/troubleshooting.md
+++ b/docs/en-US/troubleshooting.md
@@ -1,0 +1,100 @@
+---
+layout: page
+title: Troubleshooting
+permalink: /docs/en-US/troubleshooting/
+---
+
+Need help?
+
+* Let us have it! Don't hesitate to open a new issue on GitHub if you run into trouble or have any tips that we need to know.
+* The [VVV Wiki](https://github.com/varying-vagrant-vagrants/vvv/wiki) also contains documentation that may help.
+
+## Starting from Fresh
+
+Sometimes, a clean fresh start fixes things, to do this, run the following commands:
+
+```shell
+# make sure this is the latest VVV
+git pull
+# Turn off the machine
+vagrant halt
+# Destroy the machine
+vagrant destroy
+# Make sure we use the latest version of the base box§
+vagrant box update
+# Make sure the recommended vagrant plugins are installed
+vagrant plugin install vagrant-triggers vagrant-vbguest vagrant-hostsupdater
+# And that they're all up to date
+vagrant plugin update
+# Start VVV and create the VM from scratch
+vagrant up --provision
+```
+
+## Common Problems
+
+### SSH Timeout During Provision
+
+This is a generic error that can indicate multiple things, including:
+
+ - An unexpected error in the provisioner
+ - Failure to setup the connection between Vagrant and the running VM ( a handful of versions of Vagrant failed to install the necessary keys inside the VM, updating Vagrant, destroying the box, and doing a clean provision should resolve this )
+ - Local network IP clashes
+ - Firewalls
+ - Unusual network configurations
+ - Many other possible problems
+
+If this happens, do the following, and provide the results when asking for help.
+
+ - Run `vagrant ssh`, if this works and you're able to get inside the VVV machine and run commands that is useful information, and may allow you to manually run the commands to bring up nginx and PHP
+ - Halt the machine with `vagrant halt` and turn it back on in verbose logging mode using `vagrant up --provision --verbose | vvv.log`. The log file may then reveal errors that might not show in the terminal. Send this file when reporting problems.
+
+## Corrupt VM
+
+It's possible that the Virtual Machine file system may become corrupted. This might happen if your VM didn't shut down correctly, perhaps there was a power cut or your laptop ran out of power unexpectedly.
+
+In this scenario, your files should be safe on the host filesystem. If the Vagrant triggers plugin is installed, a database backup will be available. Using these, the site can be recovered from a fresh VVV box.
+
+Run `vagrant halt; vagrant destroy` to delete the Virtual Machine, followed by `vagrant up --provision` to recreate the machine. When the process is finished, restore the database from backups.
+
+For more information on backups, see the [backups](#backups) section below.
+
+
+## Common Causes of Problems
+
+### Typos in `vvv-custom.yml`
+
+If there's a typo or syntax error in `vvv-custom.yml` the provisioner will fail. Make sure the file is valid YAML when making changes to this file.
+
+### Out of Date VVV
+
+VVV is an active project, but if it isn't up to date you might suffer from bugs that have already been fixed. Do a `git pull` and restart/reprovision VVV.
+
+### Out of Date Software
+
+Mismatched Virtualbox and Guest additions can cause problems, as can older versions of Vagrant. When troubleshooting a problem, update to the latest versions of software, then verify the problem still exists after a `vagrant halt;vagrant up --provision`
+
+### Local Network IP Clashes
+
+The network configuration picks an IP of 192.168.50.4. It could cause conflicts on your existing network if you *are* on a 192.168.50.x subnet already. You can configure any IP address in the `Vagrantfile` and it will be used on the next `vagrant up --provision`
+
+### Vagrant and VirtualBox
+
+VVV relies on the stability of both Vagrant and VirtualBox. These caveats are common to Vagrant environments and are worth noting:
+* If the directory VVV is inside of is moved once provisioned (`vagrant-local`), it may break.
+    * If `vagrant destroy` is used before moving, this should be fine.
+* If VirtualBox is uninstalled, VVV will break.
+* If Vagrant is uninstalled, VVV will break.
+
+### Memory Allotment
+
+The default memory allotment for the VVV virtual machine is 1024MB. If you would like to raise or lower this value to better match your system requirements, a [you can do so with the vm_config section of `vvv-custom.yml`](vm_config.md) is in the wiki.
+
+### 64bit Ubuntu and Older CPUs
+
+Since version 1.2.0, VVV has used a 64bit version of Ubuntu. Some older CPUs (such as the popular *Intel Core 2 Duo* series) do not support this. Changing the line `config.vm.box = "ubuntu/trusty64"` to `"ubuntu/trusty32"` in the `Vagrantfile` before `vagrant up` will provision a 32bit version of Ubuntu that will work on older hardware.
+
+## Backups
+
+In the event that you're stuck or at a loss, VVV tries to generate database backups at `VVV/database/backups/*.sql`, with a file for each database.
+
+This coupled with the uploads in the file system should allow the VVV environment to be recreated from a clean slate.

--- a/docs/en-US/utilities.md
+++ b/docs/en-US/utilities.md
@@ -1,0 +1,54 @@
+---
+layout: page
+title: Utilities
+permalink: /docs/en-US/utilities/
+---
+
+Utilities are packages for VVV that install system level functionality. For example, a core utilities package is provided by default. This default utility can install phpmyadmin, webgrind, and other versions of PHP.
+
+Here are the default utilities as they would be defined in `vvv-custom.yml` in full:
+
+```YAML
+utilities:
+  core:
+    - memcached-admin
+    - opcache-status
+    - phpmyadmin
+    - webgrind
+utility-sources:
+  core: https://github.com/Varying-Vagrant-Vagrants/vvv-utilities.git
+```
+
+Utilities are defined at the end of the file, outside of the sites section. The `utility-sources` section defines the name of a utility and where it can be found.
+
+## Adding Utilities
+
+Lets say that I want to run Java 7 inside a VVV installation. In order to install java, I'll need a utility. Lets name it `java` and include it:
+
+```YAML
+utilities:
+  core:
+    - php56
+  java:
+    - java7
+utility-sources:
+  java: https://github.com/example/java-utilities.git
+```
+
+My hypothetical utility defines how to install different versions of Java, and is located in a git repository. I might have defined how to install java 8, or java 6, but here I used java 7.
+
+## How Utility Repositories Are Structured
+
+A utility repo contains folders, and each folder has a provisioner script inside.
+
+With this in mind, I would expect the java repository mentioned earlier to have this folder structure:
+
+ - java6/
+   - provision.sh
+ - java7/
+   - provision.sh
+ - java8/
+   - provision.sh
+ - readme.md
+
+The name of the subfolder maps directly on to what is put in `vvv-custom.yml`. VVV will run the `provision.sh` file, at which point it can do as it pleases. This could be installing a package via `apt-get` or something else. Other files can be included in these folders for `provision.sh` to make use of.

--- a/docs/en-US/vm_config.md
+++ b/docs/en-US/vm_config.md
@@ -1,0 +1,17 @@
+---
+layout: page
+title: vm_config
+permalink: /docs/en-US/vm-config
+---
+
+# vm_config
+
+This is an optional section of the VVV configuration file that allows setting virtual machine parameters.
+
+For example, this will tell VVV to create a Virtual Machine with 1024MB of RAM and a single cpu core:
+
+```yaml
+vm_config:
+  memory: 1024
+  cores: 1
+```

--- a/docs/en-US/vvv-config.yml.md
+++ b/docs/en-US/vvv-config.yml.md
@@ -1,0 +1,143 @@
+---
+layout: page
+title: vvv-config.yml
+permalink: /docs/en-US/vvv-config/
+---
+
+`vvv-config.yml` is the default config file that VVV uses to set itself up. Copy this file to `vvv-custom.yml` to make changes and add your own site.
+
+Here's the full default config file, with every key and option that VVV supports:
+
+```yaml
+sites:
+  wordpress-default:
+    repo: https://github.com/Varying-Vagrant-Vagrants/vvv-wordpress-default.git
+    vm_dir: /srv/www/wordpress-default
+    local_dir: /Users/janesmith/dev/www/vvv/www/wordpress-default
+    branch: master
+    skip_provisioning: false
+    allow_customfile: false
+    nginx_upstream: php
+    hosts:
+      - local.wordpress.dev
+
+  wordpress-develop:
+    repo: https://github.com/Varying-Vagrant-Vagrants/vvv-wordpress-develop.git
+    vm_dir: /srv/www/wordpress-develop
+    local_dir: /Users/janesmith/dev/www/vvv/www/wordpress-develop
+    branch: master
+    skip_provisioning: true
+    allow_customfile: false
+    nginx_upstream: php
+    hosts:
+      - develop.wordpress.dev
+
+vm_config:
+  memory: 1024
+  cores: 1
+
+utilities:
+  core:
+    - memcached-admin
+    - opcache-status
+    - phpmyadmin
+    - webgrind
+utility-sources:
+  core: https://github.com/Varying-Vagrant-Vagrants/vvv-utilities.git
+```
+
+## Anatomy of a Site config
+
+Let's break apart the `wordpress-default` site:
+
+```yaml
+sites:
+  wordpress-default:
+    repo: https://github.com/Varying-Vagrant-Vagrants/vvv-wordpress-default.git
+    vm_dir: /srv/www/wordpress-default
+    local_dir: /Users/janesmith/dev/www/vvv/www/wordpress-default
+    branch: master
+    skip_provisioning: false
+    allow_customfile: false
+    nginx_upstream: php
+    hosts:
+```
+
+When defining a site, the only required item is the name of the site. This single line would be a perfectly valid site definition:
+
+```yaml
+example-site:
+```
+
+
+### repo
+
+This specifies a git repository that contains the site to be provisioned. If set, VVV will grab the git repo, place it in the appropriate place, and provision the site
+
+There's also a shorthand version:
+
+```yaml
+example-site: https://github.com/Varying-Vagrant-Vagrants/...
+```
+
+### branch
+
+If the `repo` key is being used, and the `branch` key is set, VVV will checkout that branch instead of `master`.
+
+### vm_dir
+
+This controls the folder inside the virtual machine the sites folder is mapped on to.
+
+### local_dir
+
+This controls which folder on the host machine VVV uses for this site. By default, it uses a folder with the sites name inside the `www` subfolder.
+
+For example, a site named `test` would be inside the `www/test` folder.
+
+### skip_provisioning
+
+If there are a lot of sites in `vvv-custom.yml`, you may want to skip several sites that aren't in use. To do this, set the `skip_provisioning` key, for example:
+
+```yaml
+sites:
+  wordpress-default:
+    repo: https://github.com/Varying-Vagrant-Vagrants/vvv-wordpress-default.git
+    skip_provisioning: true
+```
+
+Now VVV will skip that site when running the provisioner. This means that the hosts, nginx config, and `vvv-init.sh` script will not be copied or ran.
+
+### allow_customfile
+
+It may be necessary to run ruby script during provisioning to do more complex things. This might be installing system wide packages inside the virtual machine etc.
+
+It's recommend that instead the `utilities` section be used when possible. Writing your own Vagrant Ruby code is an in depth topic, and could destabilise VVV if done incorrectly. This should only be used by advanced users with knowledge of the subject.
+
+### nginx_upstream
+
+This option sets where Nginx passes requests to, and is primarily for setting the PHP version used. [You can read more about it here](adding-a-new-site/changing-php-version.md)
+
+### hosts
+
+This defines the domains and hosts for VVV to listen on. If the vagrant host plugin is installed, your hosts file will automatically be updated when the machine is turned on and off
+
+```yaml
+hosts:
+  - local.wordpress.dev
+```
+
+## vm_config
+
+These settings control the Virtual Machine that Vagrant creates. By default this is 1024MB of RAM and 1 core.
+
+This configuration would tell VVV to create a virtual machine with 2GB of RAM and a single CPU core:
+
+```yaml
+vm_config:
+  memory: 2048
+  cores: 1
+```
+
+## Utilities
+
+These are repositories and packages VVV pulls in to provide services, such as MySQL, PHPMyAdmin, or Memcached. Additional versions of PHP may be added here.

--- a/docs/en-US/what-is-vvv.md
+++ b/docs/en-US/what-is-vvv.md
@@ -1,0 +1,45 @@
+---
+layout: page
+title: What is VVV?
+permalink: /docs/en-US/what-is-vvv
+---
+
+# What is VVV?
+
+Varying Vagrant Vagrants is an open source [Vagrant](https://www.vagrantup.com) configuration focused on [WordPress](https://wordpress.org) development. VVV is [MIT Licensed](https://github.com/varying-vagrant-vagrants/vvv/blob/master/LICENSE).
+
+### The Purpose of Varying Vagrant Vagrants
+
+The primary goal of Varying Vagrant Vagrants (VVV) is to provide an approachable development environment with a modern server configuration.
+
+VVV is ideal for developing themes and plugins as well as for [contributing to WordPress core](https://make.wordpress.org/core/).
+
+### What do you get?
+
+A bunch of stuff!
+
+1. [Ubuntu](http://www.ubuntu.com/) 14.04 LTS (Trusty Tahr)
+1. [WordPress Develop](https://develop.svn.wordpress.org/trunk/)
+1. [WordPress Stable](https://wordpress.org/)
+1. [WP-CLI](http://wp-cli.org/) (master branch)
+1. [nginx](http://nginx.org/) ([mainline](http://nginx.com/blog/nginx-1-6-1-7-released/) version)
+1. [MariaDB](https://mariadb.org/) 10.1
+1. [php-fpm](http://php-fpm.org/) 7.0.x
+1. [memcached](http://memcached.org/)
+1. PHP [memcache extension](https://pecl.php.net/package/memcache)
+1. PHP [xdebug extension](https://pecl.php.net/package/xdebug/)
+1. PHP [imagick extension](https://pecl.php.net/package/imagick/)
+1. [PHPUnit](https://phpunit.de/)
+1. [ack-grep](http://beyondgrep.com/)
+1. [git](http://git-scm.com/)
+1. [subversion](https://subversion.apache.org/)
+1. [ngrep](http://ngrep.sourceforge.net/usage.html)
+1. [dos2unix](http://dos2unix.sourceforge.net/)
+1. [Composer](https://github.com/composer/composer)
+1. [phpMemcachedAdmin](https://code.google.com/p/phpmemcacheadmin/)
+1. [phpMyAdmin](http://www.phpmyadmin.net/) (multi-language)
+1. [Opcache Status](https://github.com/rlerdorf/opcache-status)
+1. [Webgrind](https://github.com/jokkedk/webgrind)
+1. [NodeJs](https://nodejs.org/)
+1. [grunt-cli](https://github.com/gruntjs/grunt-cli)
+1. [Mailcatcher](http://mailcatcher.me/)


### PR DESCRIPTION
The deployment process that we have setup right now for VVV docs is more complex than it needs to be and involves strange management of the master/develop branches in VVV separate from that of actual release cycles.

This moves the documentation into the VVV website repository and makes it much easier to manage and to deploy as needed. The latest copies of the CONTRIBUTING.md and CHANGELOG.md files are now pulled from VVV's develop branch.

The last state of this documentation in the main VVV repo as well as its full history can be seen in VVV commit hash [9a930f98d9](https://github.com/Varying-Vagrant-Vagrants/VVV/tree/9a930f98d9cb2aef84c7bf85c3b6cd1da1faaa58/docs/en-US).