### PR TITLE
Remove mention of old 'vvv-hosts' file.

### DIFF
--- a/docs/en-US/adding-a-new-site/index.md
+++ b/docs/en-US/adding-a-new-site/index.md
@@ -78,11 +78,8 @@ We **strongly** recommend this.
 
 The following files should be created within the `provision` folder created above:
 
- - vvv-hosts
  - vvv-init.sh
  - vvv-nginx.conf
-
-`vvv-hosts` can be one line with the hostname of the new site set above, e.g. `vvvtest.com`.
 
 `vvv-init.sh` determines how VVV will download, install, and setup WordPress. [Read about `vvv-init.sh` and find an example to copy/paste here](setup-script.md).
 


### PR DESCRIPTION
For simplicity, the old 'vvv-hosts' file should not be mentioned on the main add-new-sites page. It is still documented on the 'custom-domains-hosts' page as being available for backward compatibility with version 1.