### PR TITLE
Add trailing slash to `what-is-vvv.md` link

### DIFF
--- a/docs/en-US/what-is-vvv.md
+++ b/docs/en-US/what-is-vvv.md
@@ -2,7 +2,7 @@
 category: 1. Introduction
 order: 2
 title: What is VVV?
-permalink: /docs/en-US/what-is-vvv
+permalink: /docs/en-US/what-is-vvv/
 ---
 
 Varying Vagrant Vagrants is an open source [Vagrant](https://www.vagrantup.com) configuration focused on [WordPress](https://wordpress.org) development. VVV is [MIT Licensed](https://github.com/varying-vagrant-vagrants/vvv/blob/master/LICENSE).


### PR DESCRIPTION
This page results in a 403 in prod, hoping this rebuild helps.