### PR TITLE
Fixes and updates some things

### DIFF
--- a/docs/en-US/installation/index.md
+++ b/docs/en-US/installation/index.md
@@ -5,22 +5,27 @@ title: Installation
 permalink: /docs/en-US/installation/
 ---
 
-1. Start with any local operating system such as Mac OS X, Linux, or Windows.
+VVV relies on Vagrant + Virtualbox, so you will need to have the following minimum requirements:
+
+- A local operating system such as Mac OS X, Linux, or Windows.
     * For Windows 8 or higher it is recommended that you run the cmd window as Administrator
-1. Install [VirtualBox 5.x](https://www.virtualbox.org/wiki/Downloads)
-1. Install [Vagrant 1.x](https://www.vagrantup.com/downloads.html)
+- Virtualisation turned on in your computers BIOS ( mostly an issue with Windows machines )
+- [VirtualBox 5.x](https://www.virtualbox.org/wiki/Downloads)
+- [Vagrant 2.x](https://www.vagrantup.com/downloads.html)
     * `vagrant` will now be available as a command in your terminal, try it out.
-    * ***Note:*** If Vagrant is already installed, use `vagrant -v` to check the version. You may want to consider upgrading if a much older version is in use.
+    * ***Note:*** If Vagrant is already installed, use `vagrant -v` to check the version. You will want to upgrade anold version is in use.
+- At least 10GB of free space
+
+Once these are installed, **reboot your computer** ( if you don't there may be networking issues ), then:
+
 1. Install some these Vagrant plugins:
     1. Install the [vagrant-hostsupdater](https://github.com/cogitatio/vagrant-hostsupdater) plugin with `vagrant plugin install vagrant-hostsupdater`
         * Note: This step is not a requirement, though it does make the process of starting up a virtual machine nicer by automating the entries needed in your local machine's `hosts` file to access the provisioned VVV domains in your browser.
-        * If you choose not to install this plugin, a manual entry should be added to your local `hosts` file that looks like this: `192.168.50.4  vvv.dev local.wordpress.dev src.wordpress-develop.dev build.wordpress-develop.dev`
+        * If you choose not to install this plugin, a manual entry should be added to your local `hosts` file that looks like this: `192.168.50.4  vvv.test local.wordpress.test src.wordpress-develop.test build.wordpress-develop.test`
     1. Install the [vagrant-triggers](https://github.com/emyl/vagrant-triggers) plugin with `vagrant plugin install vagrant-triggers`
-        * Note: This step is not a requirement. When installed, it allows for various scripts to fire when issuing commands such as `vagrant halt` and `vagrant destroy`.
-        * By default, if vagrant-triggers is installed, a `db_backup` script will run on halt, suspend, and destroy that backs up each database to a `dbname.sql` file in the `{vvv}/database/backups/` directory. These will then be imported automatically if starting from scratch. Custom scripts can be added to override this default behavior.
+        * Note: This allows for various scripts to fire when issuing commands such as `vagrant halt` and `vagrant destroy`.
+        * By default, a `db_backup` script will run on halt, suspend, and destroy that backs up each database to a `dbname.sql` file in the `{vvv}/database/backups/` directory. These will then be imported automatically if starting from scratch. Custom scripts can be added to override this default behavior.
         * If vagrant-triggers is not installed, VVV will not provide automated database backups.
-    1. Install the [vagrant-vbguest](https://github.com/dotless-de/vagrant-vbguest) plugin with `vagrant plugin install vagrant-vbguest`.
-        * Note: This step is not a requirement. When installed, it keeps the [VirtualBox Guest Additions](https://www.virtualbox.org/manual/ch04.html) kernel modules of your guest synchronized with the version of your host whenever you do `vagrant up`. This can prevent some subtle shared folder errors.
 1. Clone or extract the Varying Vagrant Vagrants project into a local directory
     * `git clone -b master git://github.com/Varying-Vagrant-Vagrants/VVV.git vagrant-local`
     * OR download and extract the repository `develop` branch [zip file](https://github.com/varying-vagrant-vagrants/vvv/archive/develop.zip) to a `vagrant-local` directory on your computer.
@@ -29,7 +34,7 @@ permalink: /docs/en-US/installation/
 1. Start the Vagrant environment with `vagrant up`
     * Be patient as the magic happens. This could take a while on the first run as your local machine downloads the required files.
     * Watch as the script ends, as an administrator or `su` ***password may be required*** to properly modify the hosts file on your local machine.
-1. Visit any of the [built in WordPress sites](built-in-wp-installs.md) or the VVV Dashboard at [http://vvv.dev](http://vvv.dev)
+1. Visit any of the [built in WordPress sites](../references/default-sites.md) or the VVV Dashboard at [http://vvv.test](http://vvv.test)
 
 Fancy, yeah?
 


### PR DESCRIPTION
 - Vagrant v2 not v1
 - Separate out OS and Vagrant/vbox into a minimum requirements section so it's not so intimidating
 - Mentioned the Virtualisation in BIOS needs to be turned on
 - Mentioned at least 10gb free space, need space for that VM, and probs some for the host OS to do its thing
 - removed the vbguest plugin mention as it sometimes causes more problems than it's worth
 - removed any question of Vagrant triggers being optional
 - stressed that a reboot is needed after virtualbox is installed
 - fixed .dev TLD's and replaced with .test
 - fix for a broken link