### PR TITLE
fix: Fix broken links to .md files

### DIFF
--- a/docs/en-US/adding-a-new-site/index.md
+++ b/docs/en-US/adding-a-new-site/index.md
@@ -18,9 +18,9 @@ To do this there are five steps:
 
 I'm going to walk through setting up a blog named vvvtest.com locally using VVV, but this could be a site currently hosted in MAMP.
 
-If you're migrating a site from VVV 1, read this page, then visit the [migration page](../migrating-vvv1.md) for further details.
+If you're migrating a site from VVV 1, read this page, then visit the [migration page](migrating-from-vvv-1-4-x/) for further details.
 
-You may also find that the default sites created by VVV are enough for what you need. [Read about the default sites here](../references/default-sites.md)
+You may also find that the default sites created by VVV are enough for what you need. [Read about the default sites here](../references/default-sites/)
 
 **Remember: Always reprovision after making changes to `vvv-custom.yml`**
 
@@ -40,7 +40,7 @@ vvvtest:
     - vvvtest.com
 ```
 
-Read here for [more information about Domains and hosts](custom-domains-hosts.md)
+Read here for [more information about Domains and hosts](custom-domains-hosts/)
 
 ## Files
 
@@ -48,7 +48,7 @@ Now that VVV knows about our site with the name `vvvtest`, it's going to look in
 
 After creating the folder, create a `provision` subfolder, e.g. `www/testables/provision`. See more below about what goes in this folder.
 
-If you'd like to change the folders VVV uses, [read here for more information](custom-paths-and-folders.md)
+If you'd like to change the folders VVV uses, [read here for more information](custom-paths-and-folders/)
 
 ### Copying In Site Files
 
@@ -76,7 +76,7 @@ The following files should be created within the `provision` folder created abov
  - vvv-init.sh
  - vvv-nginx.conf
 
-`vvv-init.sh` determines how VVV will download, install, and setup WordPress. [Read about `vvv-init.sh` and find an example to copy/paste here](setup-script.md).
+`vvv-init.sh` determines how VVV will download, install, and setup WordPress. [Read about `vvv-init.sh` and find an example to copy/paste here](setup-script/).
 
 ### Nginx config
 
@@ -100,7 +100,7 @@ server {
 }
 ```
 
-For more information about Nginx and VVV, read the [Nginx Configs page](nginx-configs.md) of adding a new site.
+For more information about Nginx and VVV, read the [Nginx Configs page](nginx-configuration/) of adding a new site.
 
 ## Reprovision
 

--- a/docs/en-US/adding-a-new-site/migrating-vvv1.md
+++ b/docs/en-US/adding-a-new-site/migrating-vvv1.md
@@ -41,7 +41,7 @@ my-test-site:
 
 ### VVV 1 Sites in Non-Standard Folders
 
-Some VVV 1 sites are in nested or non-standard folder structures. These are still supported. See the [custom paths and folders](custom-paths-and-folders.md) documentation for how to configure these sites.
+Some VVV 1 sites are in nested or non-standard folder structures. These are still supported. See the [custom paths and folders](custom-paths-and-folders/) documentation for how to configure these sites.
 
 ## Why is This Needed?
 

--- a/docs/en-US/adding-a-new-site/nginx-configs.md
+++ b/docs/en-US/adding-a-new-site/nginx-configs.md
@@ -3,7 +3,7 @@ layout: default
 category: 3. Adding a New Site
 order: 1
 title: Nginx Configuration
-permalink: /docs/en-US/adding-a-new-site/nginx-configuration/
+permalink: /docs/en-US/adding-a-new-site/nginx-configuration
 ---
 
 Some sites use Apache or IIS to serve pages, but VVV uses the popular Nginx. VVV provides an include for setting up WordPress easily, and a file for setting your own Nginx configuration on a per site basis named `vvv-nginx.conf`
@@ -58,7 +58,7 @@ set $upstream {upstream};
 
 The `{upstream}` variable is set from `vvv-custom.yml`, and is used to determine the version of PHP to use. Removing this will disable that functionality.
 
-It may be desirable to force a site to use a particular version of PHP, for details see the [changing PHP versions](changing-php-version.md) documentation.
+It may be desirable to force a site to use a particular version of PHP, for details see the [changing PHP versions](changing-php-version/) documentation.
 
 ## PHP Error Logs
 

--- a/docs/en-US/installation/index.md
+++ b/docs/en-US/installation/index.md
@@ -34,7 +34,7 @@ Once these are installed, **reboot your computer** ( if you don't there may be n
 1. Start the Vagrant environment with `vagrant up`
     * Be patient as the magic happens. This could take a while on the first run as your local machine downloads the required files.
     * Watch as the script ends, as an administrator or `su` ***password may be required*** to properly modify the hosts file on your local machine.
-1. Visit any of the [built in WordPress sites](../references/default-sites.md) or the VVV Dashboard at [http://vvv.test](http://vvv.test)
+1. Visit any of the [built in WordPress sites](../references/default-sites/) or the VVV Dashboard at [http://vvv.test](http://vvv.test)
 
 Fancy, yeah?
 
@@ -62,4 +62,4 @@ Now that you're up and running, start poking around and modifying things.
 1. Suspend the box's state in memory with `vagrant suspend` and bring it right back with `vagrant resume`.
 1. Reapply provisioning to a running box with `vagrant provision`.
 1. Destroy the box with `vagrant destroy`. Files added in the `www` directory will persist on the next `vagrant up`.
-1. Start modifying and adding local files to fit your needs. Take a look at [Adding a Site](adding-a-new-site/index.md) for tips on adding new projects.
+1. Start modifying and adding local files to fit your needs. Take a look at [Adding a Site](../adding-a-new-site/) for tips on adding new projects.

--- a/docs/en-US/troubleshooting.md
+++ b/docs/en-US/troubleshooting.md
@@ -88,7 +88,7 @@ VVV relies on the stability of both Vagrant and VirtualBox. These caveats are co
 
 ### Memory Allotment
 
-The default memory allotment for the VVV virtual machine is 1024MB. If you would like to raise or lower this value to better match your system requirements, a [you can do so with the vm_config section of `vvv-custom.yml`](vm_config.md) is in the wiki.
+The default memory allotment for the VVV virtual machine is 1024MB. If you would like to raise or lower this value to better match your system requirements, a [you can do so with the vm_config section of `vvv-custom.yml`](../vm-config/) is in the wiki.
 
 ### 64bit Ubuntu and Older CPUs
 

--- a/docs/en-US/vvv-config.yml.md
+++ b/docs/en-US/vvv-config.yml.md
@@ -2,7 +2,7 @@
 category: 5. Reference
 order: 1
 title: vvv-config.yml
-permalink: /docs/en-US/vvv-config/
+permalink: /docs/en-US/vvv-config
 ---
 
 `vvv-config.yml` is the default config file that VVV uses to set itself up. Copy this file to `vvv-custom.yml` to make changes and add your own site.
@@ -116,7 +116,7 @@ It's recommend that instead the `utilities` section be used when possible. Writi
 
 ### nginx_upstream
 
-This option sets where Nginx passes requests to, and is primarily for setting the PHP version used. [You can read more about it here](adding-a-new-site/changing-php-version.md)
+This option sets where Nginx passes requests to, and is primarily for setting the PHP version used. [You can read more about it here](../adding-a-new-site/changing-php-version/)
 
 ### hosts
 

--- a/index.md
+++ b/index.md
@@ -15,7 +15,7 @@ VVV is ideal for developing themes and plugins as well as for [contributing to W
 * Stable state of software and configuration in default provisioning.
 * Excellent and clear documentation to aid in learning and scaffolding.
 
-Read more about the [history of VVV](docs/en-US/history.md), the [governance of the project](docs/en-US/governance.md), and [how you can contribute](docs/en-US/contributing.md).
+Read more about the [history of VVV](docs/en-US/history/), the [governance of the project](docs/en-US/governance/), and [how you can contribute](https://github.com/Varying-Vagrant-Vagrants/VVV/blob/develop/.github/CONTRIBUTING.md).
 
 ## Requirements
 
@@ -27,7 +27,7 @@ In addition to VirtualBox, provider support is also included for Parallels, Hype
 
 ## Documentation
 
-The [documentation](docs/en-US/index.md) area of this site is in progress. The [VVV Wiki](https://github.com/varying-vagrant-vagrants/vvv/wiki) contains documentation that may help. Open a [new issue on GitHub](https://github.com/Varying-Vagrant-Vagrants/VVV) if you run into trouble or have any tips that we need to know.
+The [documentation](docs/en-US/) area of this site is in progress. The [VVV Wiki](https://github.com/varying-vagrant-vagrants/vvv/wiki) contains documentation that may help. Open a [new issue on GitHub](https://github.com/Varying-Vagrant-Vagrants/VVV) if you run into trouble or have any tips that we need to know.
 
 ## Copyright / License
 


### PR DESCRIPTION
I found a number of broken links to pages within the documentation site. Looks like the links were trying to point to the .md source files rather than the permalink created by Jekyll on build. This PR just fixes those links.