### PR TITLE
Wrap post titles on blog archive with anchors

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -10,7 +10,7 @@ permalink: blog/
 <div class="changelog">
 	{% for change in site.posts %}
 		<div class="changelog-item">
-			<h3>{{ change.title }}</h3>
+			<h3><a href="/{{ change.url }}/">{{ change.title }}</a></h3>
 			<p><span class="date">{{ change.date | date: "%B %d, %Y" }}</span> <span class="badge {{ change.type }}">{{ change.type }}</span></p>
 
 			{{ change.content }}


### PR DESCRIPTION
It should be possible to navigate to a single release announcement