### PR TITLE
Add edit link to ease editing the docs on GitHub

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -19,6 +19,7 @@ exclude:
   - README.md
   - Gemfile*
   - LICENCE
+github_repository_url: "https://github.com/Varying-Vagrant-Vagrants/varyingvagrantvagrants.org"
 
 
 # ----
@@ -49,7 +50,7 @@ plugins:
   - jekyll-feed
   - jekyll-paginate
   - jekyll-relative-links
-  
+
 collections:
   docs:
     title: Documentation

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -80,6 +80,7 @@
 			</div>
 			<article class="content">
 				{{ content }}
+				<p class="github-edit-link"><a href="{{site.github_repository_url}}/edit/master/{{page.path}}">Edit this page</a></p>
 			</article>
 		</section>
 

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -468,6 +468,11 @@ img {
 	background: #eff1f5;
 	border: 1px solid #dfe1e8;
 	padding: 1em 2em;
-    margin-bottom: 30px;
-    border-radius: 6px;
+	margin-bottom: 30px;
+	border-radius: 6px;
+}
+
+.github-edit-link {
+	font-size: .7em;
+	text-align: right;
 }


### PR DESCRIPTION
This adds a small edit link after the page content, see attached screenshot.


<img width="902" alt="edit-link" src="https://user-images.githubusercontent.com/617637/32551884-47212f00-c492-11e7-82f5-e905298e9b73.png">
