### PR TITLE
Remove top level menu entry for VVV

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -43,13 +43,6 @@
 
 			<nav {% if site.show_full_navigation %}class="full-navigation"{% endif %}>
 				<ul>
-					<li class="nav-item top-level {% if page.url == '/' %}current{% endif %}">
-						{% assign home = site.html_pages | where: 'url', '/' | first %}
-						<a href="{{ site.baseurl }}/">{{ home.title }}</a>
-					</li>
-				</ul>
-
-				<ul>
 					{% assign grouped = site.pages |  group_by: 'category' | sort: 'name' %}
 					{% for group in grouped %}
 						<li class="nav-item top-level {% if group.name == page.category %}current{% endif %}">


### PR DESCRIPTION
It's already available through the site logo + title.

Before:
<img width="356" alt="before" src="https://user-images.githubusercontent.com/617637/32553516-75665084-c497-11e7-8c52-f45b88b854b7.png">

After:
<img width="374" alt="after" src="https://user-images.githubusercontent.com/617637/32553535-78d0326c-c497-11e7-81a8-f351459796b0.png">

Related: #38.