### PR TITLE
Update setup-script.md

### DIFF
--- a/docs/en-US/site-templates/setup-script.md
+++ b/docs/en-US/site-templates/setup-script.md
@@ -46,13 +46,15 @@ touch ${VVV_PATH_TO_SITE}/log/access.log
 
 # Install and configure the latest stable version of WordPress
 if [[ ! -f "${VVV_PATH_TO_SITE}/public_html/wp-load.php" ]]; then
-    echo "Downloading WordPress..."
-	noroot wp core download --version="${WP_VERSION}"
+   echo "Downloading WordPress..."
+   cd ${VVV_PATH_TO_SITE}/public_html
+   noroot wp core download --version="${WP_VERSION}"
 fi
 
 if [[ ! -f "${VVV_PATH_TO_SITE}/public_html/wp-config.php" ]]; then
-  echo "Configuring WordPress Stable..."
-  noroot wp core config --dbname="${DB_NAME}" --dbuser=wp --dbpass=wp --quiet --extra-php <<PHP
+   echo "Configuring WordPress Stable..."
+   cd ${VVV_PATH_TO_SITE}/public_html
+   noroot wp core config --dbname="${DB_NAME}" --dbuser=wp --dbpass=wp --quiet --extra-php <<PHP
 define( 'WP_DEBUG', true );
 PHP
 fi


### PR DESCRIPTION
When no instance of WordPress is found, the `wp core install` command is run inside the `/provision` directory instead of `${VVV_PATH_TO_SITE}/public_html`. 
This change switches to `/public_html` before running the command.