### PR TITLE
Update list of community utilities

### DIFF
--- a/docs/en-US/utilities.md
+++ b/docs/en-US/utilities.md
@@ -65,3 +65,6 @@ Community utilities are independently developed and contributed by interested me
 
 * **VVV Solr Utilities**: Installs Solr and Java.  
   [https://github.com/ocean90/vvv-solr-utilities](https://github.com/ocean90/vvv-solr-utilities)
+  
+* **VVV GMP Utility**: Installs GMP.
+  [https://github.com/denisyilmaz/vvv-gmp-utility](https://github.com/denisyilmaz/vvv-gmp-utility)


### PR DESCRIPTION
I've created an custom utility to install [GMP](https://github.com/denisyilmaz/vvv-gmp-utility) within a custom vvv-site. To make it accessible to others it may be included in the "Community Utilities" list on the website.