### PR TITLE
Remove Google Analytics tracking from entire site

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -20,7 +20,6 @@ exclude:
   - Gemfile*
   - LICENCE
 github_repository_url: "https://github.com/Varying-Vagrant-Vagrants/varyingvagrantvagrants.org"
-google_analytics_key: "UA-57670102-1"
 
 
 # ----

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -14,18 +14,6 @@
 
 		{% feed_meta %}
 		{% seo %}
-
-		{% if jekyll.environment == 'production' and site.google_analytics_key != '' %}
-			<script>
-				(function(i,s,o,g,r,a,m){i["GoogleAnalyticsObject"]=r;i[r]=i[r]||function(){
-				(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-				m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-				})(window,document,"script","//www.google-analytics.com/analytics.js","ga");
-
-				ga("create", "{{ site.google_analytics_key }}", "auto");
-				ga("send", "pageview");
-			</script>
-		{% endif %}
 	</head>
 
 	<body>

--- a/docs/en-US/governance.md
+++ b/docs/en-US/governance.md
@@ -81,7 +81,3 @@ The `varyingvagrantvagrants.org` domain is assigned to a virtual machine, hosted
 #### S3 account
 
 Documentation from VVV's repositories is deployed directly to an S3 bucket. That bucket is managed and paid for by Jeremy Felt.
-
-#### Google Analytics
-
-Google Analytics is used to track visitors on the `varyingvagrantvagrants.org` domain. That account is managed by Jeremy Felt.


### PR DESCRIPTION
We aren't using this data for anything and it's enforcing the idea that everything in the world needs to be tracked by Google's analytic service. :)

I think I'm more comfortable knowing that 3rd party tracking is not used on varyingvagrantvagrants.org.

Nginx access logs are still stored, so we can always determine what popular pages are as necessary. I'll do some more thinking about rotating those out and anonymizing them.