### PR TITLE
Update lead developer and committer names

### DIFF
--- a/docs/en-US/governance.md
+++ b/docs/en-US/governance.md
@@ -33,6 +33,7 @@ Lead developers are trusted to make changes to all project code by merging their
 Current lead developers:
 
 * [Lorelei Aurora](https://github.com/loreleiaurora)
+* [Tom Nowell](https://github.com/tomjn)
 
 Lead developers are selected by the project lead.
 
@@ -42,12 +43,14 @@ Committers are trusted to make changes to project code by merging the pull reque
 
 Current committers:
 
+* [Daniele Scasciafratte](https://github.com/mte90)
+
+Committers emeritus:
+
 * [Weston Ruter](https://github.com/westonruter)
-* [Tom Nowell](https://github.com/tomjn)
 * [Simon Wheatley](https://github.com/simonwheatley)
 * [Luke Woodward](https://github.com/lkwdwrd)
 * [Christian Foellman](https://github.com/cfoellmann)
-* [Daniele Scasciafratte](https://github.com/mte90)
 
 Contributors who [show good judgement](http://producingoss.com/en/committers.html#choosing-committers) may be selected as committers for one or more project repositories. The decision to promote a contributor to a committer will be made by consensus between the project lead and lead developers. This decision should be based on meritocratic criteria including, but not limited to, consistent and quality pull requests, bug gardening, support answers, and general community participation.
 


### PR DESCRIPTION
This is way beyond delayed. Sorry @tomjn!

I'm still thinking of a good description for "committers emeritus". I'll probably submit another PR shortly to propose that wording.