### PR TITLE
Change vagrant box ubuntu root login

### DIFF
--- a/docs/en-US/references/default-credentials.md
+++ b/docs/en-US/references/default-credentials.md
@@ -25,7 +25,7 @@ See: [Connecting to MariaDB/MySQL](https://github.com/Varying-Vagrant-Vagrants/V
 
 Vagrant Box Ubuntu Root:
 
-__User:__ `root`
+__User:__ `vagrant`
 __Password:__ `vagrant`
 
 #### WordPress Stable One


### PR DESCRIPTION
It appears that the login for the Ubuntu box is actually vagrant:vagrant