### PR TITLE
Edit this page link URL updated.

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -72,7 +72,7 @@
 			</div>
 			<article class="content">
 				{{ content }}
-				<p class="github-edit-link"><a href="{{site.github_repository_url}}/edit/master/{{page.path}}">Edit this page</a></p>
+				<p class="github-edit-link"><a href="{{site.github_repository_url}}/edit/main/{{page.path}}">Edit this page</a></p>
 			</article>
 		</section>
 


### PR DESCRIPTION
'**Edit this page**' link has pointed to a broken URL after Github renamed "**master**" branch to "**main**" branch.  So, URL is updated to match the updated branch name.