### PR TITLE
Homepage logo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ cache/
 extensions/
 gems/
 specifications/
+.DS_Store

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -19,8 +19,10 @@
 	<body>
 		<header>
 			<h1>
-				<a href="{{ site.baseurl }}/"><img src="{{ site.baseurl }}/images/vvv-tight.png" width="40"  alt="{{ site.title }} logo"></a>
-				<a href="{{ site.baseurl }}/">{{ site.title }}</a>
+				<a href="{{ site.baseurl }}/" class="logo rainbow">__ __ __ __
+\ V\ V\ V /
+ \_/\_/\_/ 
+</a>
 				<button type="button" class="open-nav" id="open-nav"></button>
 			</h1>
 

--- a/_layouts/homepage.html
+++ b/_layouts/homepage.html
@@ -16,11 +16,13 @@
 		{% seo %}
 	</head>
 
-	<body>
+	<body class="homepage">
 		<header>
 			<h1>
-				<a href="{{ site.baseurl }}/"><img src="{{ site.baseurl }}/images/vvv-tight.png" width="40"  alt="{{ site.title }} logo"></a>
-				<a href="{{ site.baseurl }}/">{{ site.title }}</a>
+				<a href="{{ site.baseurl }}/" class="logo rainbow">__ __ __ __
+\ V\ V\ V /
+ \_/\_/\_/ 
+</a>
 				<button type="button" class="open-nav" id="open-nav"></button>
 			</h1>
 
@@ -67,12 +69,14 @@
 
 		<section class="main">
 			<div class="homepage-top">
-				<img src="{{ site.baseurl }}/images/vvv-tight.png" alt="{{ site.title }} logo" />
-				<img src="{{ site.baseurl }}/images/vvv-tight.png" alt="{{ site.title }} logo" />
-				<img src="{{ site.baseurl }}/images/vvv-tight.png" alt="{{ site.title }} logo" />
+				<div class="logo rainbow">
+__ __ __ __
+\ V\ V\ V /
+ \_/\_/\_/ 
+</div>
 				<p>A local development environment for WordPress and PHP Applications.</p>
 				<p><a class="btn" href="{{ site.baseurl }}/docs/en-US/installation/">Install VVV</a> <a  class="btn" href="https://github.com/Varying-Vagrant-Vagrants/VVV">GitHub</a></p>
-				<div class="teddybear">
+				<div class="teddybear rainbow">
  ✧ ▄▀▀▀▄▄▄▄▄▄▄▀▀▀▄ ✧ 
   ✧█▒▒░░░░░░░░░▒▒█   
 ✧   █░░█░░░░░█░░█ ✧  

--- a/_layouts/homepage.html
+++ b/_layouts/homepage.html
@@ -69,8 +69,7 @@
 
 		<section class="main">
 			<div class="homepage-top">
-				<div class="logo rainbow">
-__ __ __ __
+				<div class="logo rainbow">__ __ __ __
 \ V\ V\ V /
  \_/\_/\_/ 
 </div>

--- a/_sass/_homepage.scss
+++ b/_sass/_homepage.scss
@@ -5,6 +5,11 @@
 	padding: 5em 2em 2em 2em;
 	text-align: center;
 
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	flex-direction: column;
+
 	> img {
 		max-height: 20vh;
 	}
@@ -14,5 +19,8 @@
 		line-height: 1em;
 		margin-bottom:-2em;
 		white-space: pre;
+	}
+	.logo {
+		font-size: 42px;
 	}
 }

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -118,6 +118,10 @@ header {
 		@include align-items(center);
 		border-bottom: 1px solid rgba(0, 0, 0, 0.075);
 
+		.logo {
+			margin-top: -10px;
+		}
+
 		img {
 			/*height: $emblem-size;*/
 			width: $emblem-size;
@@ -165,10 +169,6 @@ header {
 
 		.open-nav {
 			display: none;
-		}
-
-		h1 {
-			box-shadow: inset -10px 0 10px -10px rgba(0, 0, 0, 0.1);
 		}
 	}
 }
@@ -491,4 +491,32 @@ img {
 
 .github-edit-link {
 	text-align: right;
+}
+
+.logo {
+	white-space: pre;
+	line-height: 1.266em;
+	font-size: 12px;
+	font-family: monospace;
+	font-weight: bold;
+}
+
+.rainbow {
+	background: linear-gradient(90deg, #11ff00 0%, #0090ff 45%, #ff0000 100%);
+    color: transparent;
+    -webkit-background-clip: text;
+    background-clip: text;
+    -webkit-text-fill-color: transparent;
+    text-fill-color: transparent;
+	transition: background 2s;
+
+	&:hover {
+		background-image: linear-gradient(90deg, #ffaacc 0%, #91cfff 40%, #82f369 100%);
+	}
+
+	&:active,
+	&:focus {
+		background-color: #f4d525;
+		background-image: none;
+	}
 }

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -516,7 +516,7 @@ img {
 
 	&:active,
 	&:focus {
-		background-color: #f4d525;
+		background-color: $vvv-highlight;
 		background-image: none;
 	}
 }

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -75,6 +75,14 @@ body {
 	}
 }
 
+.homepage .main {
+	margin-top: $nav-header-height;
+
+	@media (min-width: $mobile-break) {
+		margin-top: 0;
+	}
+}
+
 header {
 	$emblem-size: 35px;
 	$emblem-vertical-padding: ($nav-header-height - $emblem-size) / 2;


### PR DESCRIPTION
Replaces the VVV logo PNG with newer text based logos from the VVV status output, along with gradient backgrounds:

<img width="299" height="299" alt="Screenshot 2025-09-16 at 13 14 47" src="https://github.com/user-attachments/assets/7d0db374-dae6-44c2-8869-d9988dbe5ba7" />
<img width="1512" height="855" alt="Screenshot 2025-09-16 at 13 15 14" src="https://github.com/user-attachments/assets/7ff315f8-ee8e-4de0-ab01-b74c9b92b3fb" />

On hover a reversed gradient with slightly different colours shows:

<img width="365" height="207" alt="Screenshot 2025-09-16 at 13 15 19" src="https://github.com/user-attachments/assets/aa1cef5c-c89d-440e-831d-9b3d306fdbda" />

Yellow is used for focus/active:

<img width="157" height="99" alt="Screenshot 2025-09-16 at 13 16 51" src="https://github.com/user-attachments/assets/4b566df7-d262-45b1-894b-42d13c98a062" />
